### PR TITLE
simplified literal matching algo for lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -56,6 +56,21 @@ LexToken lex_get_nexttok(FILE *f)
     else if (ch == '\'') return lex_match_char(f, ch);
     else if (ch == '"') return lex_match_string(f, ch);
     else if (isdigit(ch)) return lex_match_numeric(f, ch);
+    else if (ch == '+' || ch == '-') {
+        ch = lex_getc(f);
+        if (isdigit(ch)) return lex_match_numeric(f, ch);
+        lex_ungetc(&ch, f);
+        return lex_match_symbols(f, ch);
+    }
+    else if (ch == '.') {
+        ch = lex_getc(f);
+        if (isdigit(ch)) {
+            lex_ungetc(&ch, f);
+            return lex_match_numeric(f, ch);
+        }
+        lex_ungetc(&ch, f);
+        return lex_match_symbols(f, ch);
+    }
     else return lex_match_symbols(f, ch);
 }
 


### PR DESCRIPTION
- lexer: fixes to matching literals
- wrote a generalised fn for matching digits
- hex digits are converted to their uppercase counterparts
- if 'p' is present in any digit, it is converted to 'e'
