### PR TITLE
several bug fixes when matching and parsing string and char literals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ REQ_DIRS       := $(BUILD_DIR) $(TARGET_DIR)
 EXEC_NAME      := scsh
 
 CC             := gcc
-CFLAGS         := -Wall -Ofast
-CDBGFLAGS      := -Wall -g -fsanitize=address -D DEBUG
+CFLAGS         := -Wall -Wno-unused-label -Ofast
+CDBGFLAGS      := -Wall -Wno-unused-label -g -fsanitize=address -D DEBUG
 DBG            := gdb -q
 
 INCLUDE        := -I $(INCLUDE_DIR) -I $(LIB_DIR) -I $(SRC_DIR)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ World's most sh*tty scripting language.
 - Build with `make`
 - Copy the executable from `taget/`.
 
+```
+USAGE:
+  scsh [FILENAMES]               execute files listed as args
+  scsh -b or --build [FILENAME]  execute files listed in file
+  scsh -t or --ast [FILENAME]    save AST as JSON to file
+  scsh -h or --help              view this message
+```
+
 ### Docs
 - Example code at [`tests/test.txt`](tests/test.txt).
 - Syntax specs at [`docs/Syntax.md`](docs/Syntax.md).

--- a/include/errcodes.h
+++ b/include/errcodes.h
@@ -1,0 +1,11 @@
+#ifndef ERRCODES_H
+#define ERRCODES_H
+
+enum ErrCodes {
+    ERR_LEXER = 1,
+    ERR_PARSER,
+    ERR_MEMORY,
+    ERR_DIE,
+};
+
+#endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -3,6 +3,6 @@
 
 #define GLOBAL_BYTES_BUFFER_LEN (128)
 
-extern char *global_currfile;
+extern const char *global_currfile;
 
 #endif

--- a/include/io.h
+++ b/include/io.h
@@ -3,7 +3,8 @@
 
 #include <stdio.h>
 
-long long io_get_filesize(FILE *file);
+long long io_get_filesize(const char *filepath);
+char **io_read_lines(const char *filepath, size_t *line_cnt);
 void io_errndie(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void io_print_srcerr(int line_no, int char_no, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,8 +16,8 @@ INCLUDE_DIR    := ../include
 EXEC_NAME      := scsh
 
 CC             := gcc
-CFLAGS         := -Wall -Ofast
-CDBGFLAGS      := -Wall -g -fsanitize=address -D _LEX_DEBUG -D DEBUG
+CFLAGS         := -Wall -Wno-unused-label -Ofast
+CDBGFLAGS      := -Wall -Wno-unused-label -g -fsanitize=address -D _LEX_DEBUG -D DEBUG
 DBG            := gdb -q
 
 INCLUDE        := -I $(INCLUDE_DIR) -I $(LIB_DIR) -I $(SRC_DIR)

--- a/src/ast/to_json.c.h
+++ b/src/ast/to_json.c.h
@@ -13,34 +13,63 @@
 
 FILE *AST2JSON_outfile = NULL;
 
-/* Helper function to escape special characters in a string */
-char* AST2JSON_escape_string(const char* input)
+/* helper function to escape special characters in a string */
+char *AST2JSON_escape_string(const char *str)
 {
-    if (!input) return NULL;
-    size_t input_len = strlen(input);
-    size_t output_len = 0;
-    for (size_t i = 0; i < input_len; ++i) {
-        if (input[i] == '"' || input[i] == '\\' || input[i] == '\n') {
-            /* Add escape character */
-            output_len += 2;
-        } else {
-            ++output_len;
+    if (!str) return NULL;
+    size_t len = strlen(str);
+    char *escaped = (char*) malloc((4 * len +1) * sizeof(char));
+    if (!escaped) parse_throw("memory allocation failed");
+    char *ptr = escaped;
+    while (*str != '\0') {
+        switch (*str) {
+            case '\a':
+                *ptr++ = '\\';
+                *ptr++ = 'a';
+                break;
+            case '\b':
+                *ptr++ = '\\';
+                *ptr++ = 'b';
+                break;
+            case '\f':
+                *ptr++ = '\\';
+                *ptr++ = 'f';
+                break;
+            case '\n':
+                *ptr++ = '\\';
+                *ptr++ = 'n';
+                break;
+            case '\r':
+                *ptr++ = '\\';
+                *ptr++ = 'r';
+                break;
+            case '\t':
+                *ptr++ = '\\';
+                *ptr++ = 't';
+                break;
+            case '\v':
+                *ptr++ = '\\';
+                *ptr++ = 'v';
+                break;
+            default:
+                if (*str < 32 || *str > 126) {
+                    /* unprintable character, escape using \xXX notation */
+                    sprintf(
+                        ptr, "\\x%02X",
+                        (unsigned char) *str);
+                    ptr += 4;
+                } else
+                    /* copy printable character as is */
+                    *ptr++ = *str;
+                break;
         }
+        ++str;
     }
-
-    char* output = (char*) malloc(output_len + 1);
-    size_t j = 0;
-    for (size_t i = 0; i < input_len; ++i) {
-        if (input[i] == '"' || input[i] == '\\' || input[i] == '\n') {
-            output[j++] = '\\';  /* Add escape character */
-        }
-        output[j++] = input[i];
-    }
-    output[j] = '\0';
-    return output;
+    *ptr = '\0';
+    return escaped;
 }
 
-/* Function to convert AST_Statements_t to JSON */
+/* function to convert AST_Statements_t to JSON */
 void AST2JSON_Statements(const AST_Statements_t *statements)
 {
     if (!statements) {
@@ -63,7 +92,7 @@ void AST2JSON_Statements(const AST_Statements_t *statements)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_Statement_t to JSON */
+/* function to convert AST_Statement_t to JSON */
 void AST2JSON_Statement(const AST_Statement_t *statement)
 {
     if (!statement) {
@@ -94,7 +123,7 @@ void AST2JSON_Statement(const AST_Statement_t *statement)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_Assignment_t to JSON */
+/* function to convert AST_Assignment_t to JSON */
 void AST2JSON_Assignment(const AST_Assignment_t *assignment)
 {
     if (!assignment) {
@@ -111,7 +140,7 @@ void AST2JSON_Assignment(const AST_Assignment_t *assignment)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_CompoundSt_t to JSON */
+/* function to convert AST_CompoundSt_t to JSON */
 void AST2JSON_CompoundSt(const AST_CompoundSt_t *compound_statement)
 {
     if (!compound_statement) {
@@ -135,7 +164,7 @@ void AST2JSON_CompoundSt(const AST_CompoundSt_t *compound_statement)
     }
 }
 
-/* Function to convert AST_IfBlock_t to JSON */
+/* function to convert AST_IfBlock_t to JSON */
 void AST2JSON_IfBlock(const AST_IfBlock_t *if_block)
 {
     if (!if_block) {
@@ -156,7 +185,7 @@ void AST2JSON_IfBlock(const AST_IfBlock_t *if_block)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_ElseIfBlock_t to JSON */
+/* function to convert AST_ElseIfBlock_t to JSON */
 void AST2JSON_ElseIfBlock(const AST_ElseIfBlock_t *else_if_block)
 {
     if (!else_if_block) {
@@ -173,7 +202,7 @@ void AST2JSON_ElseIfBlock(const AST_ElseIfBlock_t *else_if_block)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_ElseIfSt_t to JSON */
+/* function to convert AST_ElseIfSt_t to JSON */
 void AST2JSON_ElseIfSt(const AST_ElseIfSt_t *else_if_st)
 {
     if (!else_if_st) {
@@ -190,7 +219,7 @@ void AST2JSON_ElseIfSt(const AST_ElseIfSt_t *else_if_st)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_WhileBlock_t to JSON */
+/* function to convert AST_WhileBlock_t to JSON */
 void AST2JSON_WhileBlock(const AST_WhileBlock_t *while_block)
 {
     if (!while_block) {
@@ -263,7 +292,7 @@ void AST2JSON_Block(const AST_Block_t *block)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_Expression_t to JSON */
+/* function to convert AST_Expression_t to JSON */
 void AST2JSON_Expression(const AST_Expression_t *expression)
 {
     if (!expression) {
@@ -344,7 +373,7 @@ void AST2JSON_Expression(const AST_Expression_t *expression)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_CommaSepList_t to JSON */
+/* function to convert AST_CommaSepList_t to JSON */
 void AST2JSON_CommaSepList(const AST_CommaSepList_t *comma_list)
 {
     if (!comma_list) {
@@ -370,7 +399,7 @@ void AST2JSON_CommaSepList(const AST_CommaSepList_t *comma_list)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_Operand_t to JSON */
+/* function to convert AST_Operand_t to JSON */
 void AST2JSON_Operand(const AST_Operand_t *operand)
 {
     if (!operand) {
@@ -400,7 +429,7 @@ void AST2JSON_Operand(const AST_Operand_t *operand)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_Literal_t to JSON */
+/* function to convert AST_Literal_t to JSON */
 void AST2JSON_Literal(const AST_Literal_t *literal)
 {
     if (!literal) {
@@ -417,11 +446,19 @@ void AST2JSON_Literal(const AST_Literal_t *literal)
             fprintf(AST2JSON_outfile, ", \"data\": ");
             fprintf(AST2JSON_outfile, "%s", literal->data.bul ? "true" : "false");
             break;
-        case DATA_TYPE_CHR:
+        case DATA_TYPE_CHR: {
+            char chr[2] = { literal->data.chr, '\0' };
+            char *escaped_chr = AST2JSON_escape_string(chr);
             fprintf(AST2JSON_outfile, ", \"type\": \"DATA_TYPE_CHR\"");
             fprintf(AST2JSON_outfile, ", \"data\": ");
-            fprintf(AST2JSON_outfile, "\"%c\"", literal->data.chr);
+            if (escaped_chr) {
+                fprintf(AST2JSON_outfile, "\"%s\"", escaped_chr);
+                free(escaped_chr);
+            } else {
+                fprintf(AST2JSON_outfile, "null");
+            }
             break;
+        }
         case DATA_TYPE_I64:
             fprintf(AST2JSON_outfile, ", \"type\": \"DATA_TYPE_I64\"");
             fprintf(AST2JSON_outfile, ", \"data\": ");
@@ -436,7 +473,7 @@ void AST2JSON_Literal(const AST_Literal_t *literal)
         case DATA_TYPE_INTERP_STR: {
             fprintf(AST2JSON_outfile, ", \"type\": \"DATA_TYPE_STR\"");
             fprintf(AST2JSON_outfile, ", \"data\": ");
-            char* escaped_str = AST2JSON_escape_string(literal->data.str);
+            char *escaped_str = AST2JSON_escape_string(literal->data.str);
             if (escaped_str) {
                 fprintf(AST2JSON_outfile, "\"%s\"", escaped_str);
                 free(escaped_str);
@@ -459,7 +496,7 @@ void AST2JSON_Literal(const AST_Literal_t *literal)
     fprintf(AST2JSON_outfile, "}");
 }
 
-/* Function to convert AST_Identifier_t to JSON */
+/* function to convert AST_Identifier_t to JSON */
 void AST2JSON_Identifier(const AST_Identifier_t *identifier)
 {
     if (!identifier) {

--- a/src/ast/to_json.c.h
+++ b/src/ast/to_json.c.h
@@ -505,9 +505,11 @@ void AST2JSON_ProcedureMap()
 
 void AST2JSON_convert(const char *filepath)
 {
-    AST2JSON_outfile = fopen(filepath, "wb");
+    if (!strcmp(filepath, "-")) AST2JSON_outfile = stdout;
+    else AST2JSON_outfile = fopen(filepath, "wb");
     AST2JSON_ProcedureMap();
-    fclose(AST2JSON_outfile);
+    if (AST2JSON_outfile != stdout)
+        fclose(AST2JSON_outfile);
 }
 
 #else

--- a/src/ast/to_json.c.h
+++ b/src/ast/to_json.c.h
@@ -51,6 +51,14 @@ char *AST2JSON_escape_string(const char *str)
                 *ptr++ = '\\';
                 *ptr++ = 'v';
                 break;
+            case '\\':
+                *ptr++ = '\\';
+                *ptr++ = '\\';
+                break;
+            case '\"':
+                *ptr++ = '\\';
+                *ptr++ = '"';
+                break;
             default:
                 if (*str < 32 || *str > 126) {
                     /* unprintable character, escape using \xXX notation */

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,4 +1,4 @@
 #include <stddef.h>
 #include "globals.h"
 
-char *global_currfile = NULL;
+const char *global_currfile = NULL;

--- a/src/io.c
+++ b/src/io.c
@@ -38,19 +38,23 @@ char **io_read_lines(const char *filepath, size_t *line_cnt)
         /* check if matrix needs to be resized */
         if (i >= row_size) {
             row_size = row_size * 2 +1;
-            buffer = (char**) realloc(buffer, row_size * sizeof(char*));
+L_BUFFRZ1:  buffer = (char**) realloc(buffer, row_size * sizeof(char*));
             if (!buffer) io_errndie("io_read_lines: memory reallocation failed");
+            /* set garbage to NULL or else realloc will fail at label L_BUFFRZ2 */
             buffer[i] = NULL;
         }
         if (j >= col_size) {
             col_size = col_size * 2 +1;
-            buffer[i] = (char*) realloc(buffer[i], col_size * sizeof(char));
+L_BUFFRZ2:  buffer[i] = (char*) realloc(buffer[i], col_size * sizeof(char));
             if (!buffer[i]) io_errndie("io_read_lines: memory reallocation failed");
         }
         if (c == '\n') {
             /* null-terminate the string and reset column size */
             buffer[i][j] = '\0';
             col_size = j = 0;
+            /* set garbage to NULL or else realloc will fail at label L_BUFFRZ2
+               the condition ensures is within range coz the buffer isn't resized
+               before L_BUFFRZ1 */
             if (i < row_size -1) buffer[++i] = NULL;
             continue;
         }

--- a/src/io.c
+++ b/src/io.c
@@ -6,24 +6,67 @@
 #include "globals.h"
 #include "io.h"
 
-long long io_get_filesize(FILE *file)
+long long io_get_filesize(const char *filepath)
 {
-    long long fileSize;
+    FILE *file = fopen(filepath, "rb");
+    if (!file) io_errndie("io_get_filesize: couldn't read file: '%s'", filepath);
+    long long filesz = -1LL;
+    if (fseek(file, 0, SEEK_END) != 0)
+        io_errndie("io_get_filesize: error seeking to end of file");
+    filesz = ftell(file);
+    if (filesz == -1LL)
+        io_errndie("io_get_filesize: error getting the file size");
+    if (fseek(file, 0, SEEK_SET) != 0)
+        io_errndie("io_get_filesize: error seeking to the beginning of the file");
+    fclose(file);
+    return filesz;
+}
 
-    if (fseek(file, 0, SEEK_END) != 0) {
-        fprintf(stderr, "scsh: io_get_filesize: error seeking to end of file\n");
-        return -1;
+char **io_read_lines(const char *filepath, size_t *line_cnt)
+{
+    size_t row_size = 0;
+    size_t col_size = 0;
+    int i = 0, j = 0;
+    char c = 0;
+    char **buffer = NULL;
+
+    FILE *f = fopen(filepath, "rb");
+    if (!f) io_errndie("io_read_lines: couldn't read file: '%s'", filepath);
+
+    /* read characters from the file */
+    while ((c = fgetc(f)) != (char) EOF) {
+        /* check if matrix needs to be resized */
+        if (i >= row_size) {
+            row_size = row_size * 2 +1;
+            buffer = (char**) realloc(buffer, row_size * sizeof(char*));
+            if (!buffer) io_errndie("io_read_lines: memory reallocation failed");
+            buffer[i] = NULL;
+        }
+        if (j >= col_size) {
+            col_size = col_size * 2 +1;
+            buffer[i] = (char*) realloc(buffer[i], col_size * sizeof(char));
+            if (!buffer[i]) io_errndie("io_read_lines: memory reallocation failed");
+        }
+        if (c == '\n') {
+            /* null-terminate the string and reset column size */
+            buffer[i][j] = '\0';
+            col_size = j = 0;
+            if (i < row_size -1) buffer[++i] = NULL;
+            continue;
+        }
+        buffer[i][j] = c;
+        ++j;
     }
-    fileSize = ftell(file);
-    if (fileSize == -1L) {
-        fprintf(stderr, "scsh: io_get_filesize: error getting the file size\n");
-        return -1;
+    fclose(f);
+    /* null-terminate the last string if j is pointing to its end */
+    if (j == col_size -1) {
+        buffer[i] = (char*) realloc(buffer[i], (j+1) * sizeof(char));
+        if (!buffer[i]) io_errndie("io_read_lines: memory reallocation failed");
+        buffer[i][j] = '\0';
     }
-    if (fseek(file, 0, SEEK_SET) != 0) {
-        fprintf(stderr, "scsh: io_get_filesize: error seeking to the beginning of the file\n");
-        return -1;
-    }
-    return fileSize;
+    /* update the number of lines */
+    *line_cnt = i +1;
+    return buffer;
 }
 
 void io_errndie(const char *fmt, ...)

--- a/src/io.c
+++ b/src/io.c
@@ -5,6 +5,7 @@
 
 #include "globals.h"
 #include "io.h"
+#include "errcodes.h"
 
 long long io_get_filesize(const char *filepath)
 {
@@ -83,7 +84,7 @@ void io_errndie(const char *fmt, ...)
     va_end(args);
     fflush(stderr);
     fprintf(stderr, "\n");
-    exit(1);
+    exit(ERR_DIE);
 }
 
 void io_print_srcerr(int line_no, int char_no, const char *fmt, ...)

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -7,6 +7,7 @@
 #include "io.h"
 #include "lexer.h"
 #include "parser.h"
+#include "errcodes.h"
 
 LexBuffer *lex_buffer = NULL;
 LexToken lex_currtok = LEXTOK_INVALID;
@@ -133,6 +134,8 @@ LexToken lex_get_nexttok(FILE *f)
 void lex_throw(const char *msg)
 {
     if (!msg) abort();
-    io_print_srcerr(lex_line_no, lex_char_no, "lexing error: %s", msg);
-    exit(1);
+    int line = lex_line_no;
+    if (lex_currtok == LEXTOK_NEWLINE) --line;
+    io_print_srcerr(line, lex_char_no, "lexing error: after token '%s': %s", lex_get_symbol(lex_currtok), msg);
+    exit(ERR_LEXER);
 }

--- a/src/lexer/io.c.h
+++ b/src/lexer/io.c.h
@@ -5,7 +5,7 @@
 
 char lex_getc(FILE *f)
 {
-    char c = fgetc(f);
+    char c = getc(f);
     if (!c) return 0;
     if (c == (char) EOF) return (char) EOF;
     if (!lex_is_printable(c))
@@ -13,7 +13,7 @@ char lex_getc(FILE *f)
     if (c > 127) lex_throw("non-ascii symbol found");
     // ignore single line comments
     if (c == '#') while (c != '\n') {
-        c = fgetc(f);
+        c = getc(f);
         if (!c) return 0;
         if (c == (char) EOF) return (char) EOF;
         if (!lex_is_printable(c))

--- a/src/lexer/match_literals.c.h
+++ b/src/lexer/match_literals.c.h
@@ -43,6 +43,7 @@ LexToken lex_match_char(FILE *f, char ch)
             continue;
         }
         if (ch == '\'') break;
+        if (ch == '\n') lex_throw("character literal cannot have un-escaped newline");
         if (ch == (char) EOF) lex_throw("unexpected end of file");
         lex_buffpush(ch);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -9,22 +9,84 @@
 
 #include "ast/to_json.h"
 
+void main_parsefiles(const char **filepaths, int file_cnt);
+
 int main(int argc, char **argv)
 {
     if (argc < 2) io_errndie("no args provided");
-    for (int i = 1; i < argc; i++) {
-        global_currfile = argv[i];
-        FILE *f = (argv[i][0] == '-' && !argv[i][1]) ?
+
+    char **lines = NULL;
+    size_t line_cnt = 0;
+    char* ast_filename = NULL;
+
+    /* start from 1 to skip program name */
+    int index = 1;
+
+    /* check if -h or --help is present */
+    if (!strcmp(argv[index], "-h") || !strcmp(argv[index], "--help")) {
+        printf("USAGE:\n"
+               "  scsh [FILENAMES]               execute files listed as args\n"
+               "  scsh -b or --build [FILENAME]  execute files listed in file\n"
+               "  scsh -t or --ast [FILENAME]    save AST as JSON to file\n"
+               "  scsh -h or --help              view this message\n"
+        );
+        exit(0);
+    }
+
+    /* check if -t or --ast is present */
+    if (!strcmp(argv[index], "-t") || !strcmp(argv[index], "--ast")) {
+        if (argc < 3) io_errndie("ast file path not provided");
+        ast_filename = argv[++index];
+        ++index;
+    }
+
+    /* check if -b or --build is present */
+    if (!strcmp(argv[index], "-b") || !strcmp(argv[index], "--build")) {
+        if (argc < 3) io_errndie("build file path not provided");
+        lines = io_read_lines(argv[++index], &line_cnt);
+        if (!lines) io_errndie("build file content is null");
+        ++index;
+        if (index < argc) io_errndie("too many arguments: '%s' onwards", argv[index]);
+    }
+
+    /* if file paths are taken from argv, don't free lines */
+    bool from_argv = false;
+
+    /* if no --build set lines = &argv[index] */
+    if (!lines) {
+        lines = &argv[index];
+        line_cnt = argc - index;
+        from_argv = true;
+    }
+
+    main_parsefiles((const char**) lines, line_cnt);
+
+    if (!from_argv && lines) {
+        for (size_t i = 0; i < line_cnt; ++i)
+            free(lines[i]);
+        free(lines);
+    }
+
+    /* save the AST as JSON */
+    if (ast_filename) AST2JSON_convert(ast_filename);
+
+    /* clear the entire AST */
+    AST_ProcedureMap_clear();
+
+    return 0;
+}
+
+void main_parsefiles(const char **filepaths, int file_cnt)
+{
+    if (file_cnt < 1) io_errndie("no file paths provided");
+    for (int i = 0; i < file_cnt; ++i) {
+        global_currfile = filepaths[i];
+        FILE *f = (filepaths[i][0] == '-' && !filepaths[i][1]) ?
             stdin :
-            fopen(argv[i], "rb");
-        if (!f) io_errndie("couldn't read file: '%s'", argv[i]);
-        /* Auto pushes module names to a module stack */
+            fopen(filepaths[i], "rb");
+        if (!f) io_errndie("couldn't read file: '%s'", filepaths[i]);
+        /* auto pushes module names to a module stack */
         parse_interpret(f);
         if (f != stdin) fclose(f);
     }
-    /* Save the AST as JSON */
-    AST2JSON_convert("docs/SyntaxTree.json");
-    /* Clear the entire AST */
-    AST_ProcedureMap_clear();
-    return 0;
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -8,6 +8,7 @@
 #include "io.h"
 #include "lexer.h"
 #include "parser.h"
+#include "errcodes.h"
 #include "ast/nodes.h"
 #include "ast/util.h"
 
@@ -552,5 +553,5 @@ void parse_throw(const char *msg)
     int line = lex_line_no;
     if (lex_currtok == LEXTOK_NEWLINE) --line;
     io_print_srcerr(line, lex_char_no, "parsing error: %s on '%s'", msg, lex_get_symbol(lex_currtok));
-    exit(2);
+    exit(ERR_PARSER);
 }

--- a/src/parser/parse_bool.c.h
+++ b/src/parser/parse_bool.c.h
@@ -13,10 +13,7 @@ bool parse_bool(const char *str)
 {
     if (!strcmp(lex_get_buffstr(), "true"))  return true;
     if (!strcmp(lex_get_buffstr(), "false")) return false;
-    char *err_msg = malloc(strlen(str) + GLOBAL_BYTES_BUFFER_LEN);
-    sprintf(err_msg, "invalid boolean literal: '%s'", str);
-    parse_throw(err_msg);
-    free(err_msg);
+    parse_throw("invalid boolean literal");
     return false;
 }
 

--- a/src/parser/parse_chr.c.h
+++ b/src/parser/parse_chr.c.h
@@ -10,6 +10,7 @@
 
 char parse_char(const char *str)
 {
+    if (!str || !strcmp(str, "NULL")) return '\0';
     char c = str[0];
     const size_t len = strlen(str);
 

--- a/src/parser/parse_chr.c.h
+++ b/src/parser/parse_chr.c.h
@@ -12,13 +12,13 @@ char parse_char(const char *str)
 {
     char c = str[0];
     int len = strlen(str);
-    char *err_msg = NULL;
 
-    // If the input string has only one character, return it
+    /* if the input string has only one character, return it */
     if (len == 1) c = str[0];
 
-    // If the input string has two characters and the first character is a backslash,
-    // then the second character is an escape sequence
+    /* if the input string has two characters and the first
+       character is a backslash, then the second character is an
+       escape sequence */
     else if (len == 2 && str[0] == '\\') {
         switch (str[1]) {
             case 'a': c = '\a'; break;
@@ -28,52 +28,29 @@ char parse_char(const char *str)
             case 'r': c = '\r'; break;
             case 't': c = '\t'; break;
             case 'v': c = '\v'; break;
-            case '\\': c = '\\'; break;
-            case '\'': c = '\''; break;
-            case '\"': c = '\"'; break;
-            case '\?': c = '\?'; break;
-            default:
-                err_msg = malloc(strlen(str) + GLOBAL_BYTES_BUFFER_LEN);
-                sprintf(err_msg, "invalid escape sequence: '\\%c'", str[1]);
-                parse_throw(err_msg);
-                free(err_msg);
+            case '0': c = '\0'; break;
+            default: c = str[1]; break;
         }
     }
 
-    // If the input string starts with '\x', it is a hexadecimal escape sequence
-    else if (len >= 4 && str[0] == '\\' && str[1] == 'x') {
-        char hex[3];
-        hex[0] = str[2];
-        hex[1] = str[3];
-        hex[2] = '\0';
-        int num = (int) strtol(hex, NULL, 16);
-        c = (char) num;
+    /* if the input string starts with '\x', it is a hexadecimal escape sequence */
+    else if (len >= 3 && str[0] == '\\' && str[1] == 'x' && isxdigit(str[2])) {
+        char* endptr;
+        int res = strtol(&str[2], &endptr, 16);
+        if (!*endptr && 0 <= res && res <= 255) c = (char) res;
+        else parse_throw("invalid hex escape sequence");
     }
 
-    // If the input string starts with '\', it is an octal escape sequence
-    else if (len > 1 && str[0] == '\\') {
-        int num = 0;
-        int i;
-        for (i = 1; i < len && i <= 3; i++)
-            if (str[i] >= '0' && str[i] <= '7')
-                num = num * 8 + (str[i] - '0');
-            else break;
-        if (i == len) c = (char) num;
-        else {
-            err_msg = malloc(strlen(str) + GLOBAL_BYTES_BUFFER_LEN);
-            sprintf(err_msg, "invalid escape sequence: '%s'", str);
-            parse_throw(err_msg);
-            free(err_msg);
-        }
+    /* if the input string starts with '\', it is an octal escape sequence */
+    else if (len >= 2 && str[0] == '\\' && isdigit(str[1])) {
+        char* endptr;
+        int res = strtol(&str[1], &endptr, 8);
+        if (!*endptr && 0 <= res && res <= 255) c = (char) res;
+        else parse_throw("invalid octal escape sequence");
     }
 
-    // If the input string has more than two characters, it is an error
-    else {
-        err_msg = malloc(strlen(str) + GLOBAL_BYTES_BUFFER_LEN);
-        sprintf(err_msg, "invalid character token: '%s'", str);
-        parse_throw(err_msg);
-        free(err_msg);
-    }
+    /* if the input string has more than two characters, it is an error */
+    else parse_throw("invalid character token");
 
     return c;
 }

--- a/src/parser/parse_chr.c.h
+++ b/src/parser/parse_chr.c.h
@@ -11,7 +11,7 @@
 char parse_char(const char *str)
 {
     char c = str[0];
-    int len = strlen(str);
+    const size_t len = strlen(str);
 
     /* if the input string has only one character, return it */
     if (len == 1) c = str[0];
@@ -34,7 +34,7 @@ char parse_char(const char *str)
     }
 
     /* if the input string starts with '\x', it is a hexadecimal escape sequence */
-    else if (len >= 3 && str[0] == '\\' && str[1] == 'x' && isxdigit(str[2])) {
+    else if (len == 4 && str[0] == '\\' && str[1] == 'x' && isxdigit(str[2])) {
         char* endptr;
         int res = strtol(&str[2], &endptr, 16);
         if (!*endptr && 0 <= res && res <= 255) c = (char) res;
@@ -42,7 +42,7 @@ char parse_char(const char *str)
     }
 
     /* if the input string starts with '\', it is an octal escape sequence */
-    else if (len >= 2 && str[0] == '\\' && isdigit(str[1])) {
+    else if (len == 4 && str[0] == '\\' && isdigit(str[1])) {
         char* endptr;
         int res = strtol(&str[1], &endptr, 8);
         if (!*endptr && 0 <= res && res <= 255) c = (char) res;

--- a/src/parser/parse_i64.c.h
+++ b/src/parser/parse_i64.c.h
@@ -12,47 +12,46 @@
 
 int64_t parse_int(const char *str, int base)
 {
-    // Check that the base is valid
-    if (base != 2 && base != 8 && base != 10 && base != 16) {
+    /* check that the base is valid */
+    if (base != 2 && base != 8 && base != 10 && base != 16)
         parse_throw("unsupported base");
-    }
 
-    char *endptr;    // Pointer to the first invalid character in the input string
-    int64_t result;  // The parsed integer value
-    errno = 0;       // Set errno to 0 before calling strtol
+    char *endptr;
+    int64_t result = 0;
 
-    // Handle scientific notation separately
+    /* set errno to 0 before calling strtol */
+    errno = 0;
+
+    /* handle scientific notation separately */
     if (strchr(str, 'e')) {
-        result = strtol(str, &endptr, base);  // Parse the integer part before the 'e'
-        if (errno || *endptr != 'e') {
+        /* parse the integer part before the 'e' */
+        result = strtol(str, &endptr, base);
+        if (errno || *endptr != 'e')
             parse_throw("invalid integer format");
-        }
-        endptr++;  // Skip over the 'e' character
-
+        /* skip over the 'e' character */
+        ++endptr;
         char *exponent_endptr;
-        int64_t exponent = strtol(endptr, &exponent_endptr, 10);  // Parse the exponent value
-        if (errno || exponent_endptr == endptr || *exponent_endptr != '\0') {
+        /* parse the exponent value */
+        int64_t exponent = strtol(endptr, &exponent_endptr, 10);
+        if (errno || exponent_endptr == endptr || *exponent_endptr != '\0')
             parse_throw("invalid integer format");
-        }
-
-        // Check that the resulting value is representable in int64_t
+        /* check that the resulting value is representable in int64_t */
         if (exponent >= 0) {
-            if (exponent > 18 || (result >= INT64_MAX / (int64_t)(1LL << exponent))) {
+            if ( exponent > 18 || (result >= INT64_MAX / (int64_t) (1LL << exponent)) )
                 parse_throw("integer overflow");
-            }
-            result *= (int64_t)(1LL << exponent);  // Multiply by 10^exponent
+            /* multiply by 10^exponent */
+            result *= (int64_t) (1LL << exponent);
         } else {
-            if (exponent < -18 || (result <= INT64_MIN / (int64_t)(1LL << (-exponent)))) {
+            if ( exponent < -18 || (result <= INT64_MIN / (int64_t) (1LL << (-exponent))) )
                 parse_throw("integer underflow");
-            }
-            result /= (int64_t)(1LL << (-exponent));  // Divide by 10^-exponent
+            /* divide by 10^-exponent */
+            result /= (int64_t) (1LL << (-exponent));
         }
     } else {
-        // Parse the integer value using strtol
+        /* parse the integer value using strtol */
         result = strtol(str, &endptr, base);
-        if (errno || *endptr != '\0') {
+        if (errno || *endptr != '\0')
             parse_throw("invalid integer format");
-        }
     }
 
     return result;

--- a/src/parser/parse_str.c.h
+++ b/src/parser/parse_str.c.h
@@ -8,6 +8,7 @@ char *parse_str(const char *str)
 {
     int len = strlen(str);
     char *parsed_str = malloc(len +1);
+    if (!parsed_str) parse_throw("memory allocation failed");
     int parsed_index = 0;
     for (int i = 0; i < len; ++i) {
         /* if the current character is a backslash, it might be an escape sequence */

--- a/src/parser/parse_str.c.h
+++ b/src/parser/parse_str.c.h
@@ -6,15 +6,64 @@
 /** Calls strdup, remember to free */
 char *parse_str(const char *str)
 {
-    fprintf(stderr, "scsh: warning: parser/parse_str.c.h: 'parse_str' is unimplemented\n");
-    return strdup(str);
+    int len = strlen(str);
+    char *parsed_str = malloc(len +1);
+    int parsed_index = 0;
+    for (int i = 0; i < len; ++i) {
+        /* if the current character is a backslash, it might be an escape sequence */
+        if (str[i] == '\\') {
+            /* move to the next character after the backslash */
+            ++i;
+            if (i >= len) {
+                parse_throw("incomplete escape sequence");
+                free(parsed_str);
+            }
+            /* octal escape sequence */
+            if (isdigit(str[i])) {
+                char *endptr;
+                int res = strtol(&str[i], &endptr, 8);
+                if (!*endptr && 0 <= res && res <= 255) {
+                    parsed_str[parsed_index++] = (char) res;
+                    /* update the loop index */
+                    i += endptr - &str[i] -1;
+                } else parse_throw("invalid octal escape sequence");
+            }
+            /* hex escape sequence */
+            else if (str[i] == 'x' && isxdigit(str[i + 1])) {
+                char *endptr;
+                int res = strtol(&str[i+1], &endptr, 16);
+                if (!*endptr && 0 <= res && res <= 255) {
+                    parsed_str[parsed_index++] = (char) res;
+                    /* update the loop index */
+                    i += endptr - &str[i];
+                } else parse_throw("invalid hex escape sequence");
+            }
+            /* other escape sequences */
+            else switch (str[i]) {
+                case 'a': parsed_str[parsed_index++] = '\a'; break;
+                case 'b': parsed_str[parsed_index++] = '\b'; break;
+                case 'f': parsed_str[parsed_index++] = '\f'; break;
+                case 'n': parsed_str[parsed_index++] = '\n'; break;
+                case 'r': parsed_str[parsed_index++] = '\r'; break;
+                case 't': parsed_str[parsed_index++] = '\t'; break;
+                case 'v': parsed_str[parsed_index++] = '\v'; break;
+                case '0': parsed_str[parsed_index++] = '\0'; break;
+                default:
+                    parsed_str[parsed_index++] = str[i];
+                    break;
+            }
+        } else
+            parsed_str[parsed_index++] = str[i];
+    }
+    /* null-terminate the parsed string */
+    parsed_str[parsed_index] = '\0';
+    return parsed_str;
 }
 
 /** Calls strdup, remember to free */
 char *parse_interpstr(const char *str)
 {
-    fprintf(stderr, "scsh: warning: parser/parse_str.c.h: 'parse_interpstr' is unimplemented\n");
-    return strdup(str);
+    return parse_str(str);
 }
 
 #else

--- a/src/parser/parse_str.c.h
+++ b/src/parser/parse_str.c.h
@@ -6,7 +6,7 @@
 /** Calls strdup, remember to free */
 char *parse_str(const char *str)
 {
-    int len = strlen(str);
+    const size_t len = strlen(str);
     char *parsed_str = malloc(len +1);
     if (!parsed_str) parse_throw("memory allocation failed");
     int parsed_index = 0;
@@ -20,23 +20,25 @@ char *parse_str(const char *str)
                 free(parsed_str);
             }
             /* octal escape sequence */
-            if (isdigit(str[i])) {
+            if ( isdigit(str[i]) && len - (i+1) >= 2 && isdigit(str[i+1]) && isdigit(str[i+2]) ) {
                 char *endptr;
-                int res = strtol(&str[i], &endptr, 8);
+                char oct[4] = { str[i], str[i+1], str[i+2], '\0' };
+                int res = strtol(oct, &endptr, 8);
                 if (!*endptr && 0 <= res && res <= 255) {
                     parsed_str[parsed_index++] = (char) res;
                     /* update the loop index */
-                    i += endptr - &str[i] -1;
+                    i += 2;
                 } else parse_throw("invalid octal escape sequence");
             }
             /* hex escape sequence */
-            else if (str[i] == 'x' && isxdigit(str[i + 1])) {
+            else if ( str[i] == 'x' && len - (i+1) >= 2 && isxdigit(str[i+1]) && isxdigit(str[i+2]) ) {
                 char *endptr;
-                int res = strtol(&str[i+1], &endptr, 16);
+                char hex[3] = { str[i+1], str[i+2], '\0' };
+                int res = strtol(hex, &endptr, 16);
                 if (!*endptr && 0 <= res && res <= 255) {
                     parsed_str[parsed_index++] = (char) res;
                     /* update the loop index */
-                    i += endptr - &str[i];
+                    i += 2;
                 } else parse_throw("invalid hex escape sequence");
             }
             /* other escape sequences */

--- a/src/parser/parse_str.c.h
+++ b/src/parser/parse_str.c.h
@@ -6,6 +6,7 @@
 /** Calls strdup, remember to free */
 char *parse_str(const char *str)
 {
+    if (!str || !strcmp(str, "NULL")) str = "\0";
     const size_t len = strlen(str);
     char *parsed_str = malloc(len +1);
     if (!parsed_str) parse_throw("memory allocation failed");


### PR DESCRIPTION
- main: updated vli args
- added helpful comments
- updated README.md
- bugfix: lexer: for escape sequences
- added code to parse strings
- updated code to parse chars
- code refactor; parse_throw automatically displays error token so no need to sprintf-ing a custom error msg
- improved error reporting
- improvements made to AST to JSON module, w/ major improvements to escape_string fn
- updates to string and char literal parsers
- added support for empty string and empty char
- AST2JSON_escape_string: added proper printing for \\ and \"
