### PR TITLE
major lexer numeric token bugs fixed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ EXEC_NAME      := scsh
 
 CC             := gcc
 CFLAGS         := -Wall -Wno-unused-label -Ofast
-CDBGFLAGS      := -Wall -Wno-unused-label -g -fsanitize=address -D LEX_DEBUG -D DEBUG
+CDBGFLAGS      := -Wall -Wno-unused-label -g -fsanitize=address -D _LEX_DEBUG -D DEBUG
 DBG            := gdb -q
 
 INCLUDE        := -I $(INCLUDE_DIR) -I $(LIB_DIR) -I $(SRC_DIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ EXEC_NAME      := scsh
 
 CC             := gcc
 CFLAGS         := -Wall -Wno-unused-label -Ofast
-CDBGFLAGS      := -Wall -Wno-unused-label -g -fsanitize=address -D _LEX_DEBUG -D DEBUG
+CDBGFLAGS      := -Wall -Wno-unused-label -g -fsanitize=address -D LEX_DEBUG -D DEBUG
 DBG            := gdb -q
 
 INCLUDE        := -I $(INCLUDE_DIR) -I $(LIB_DIR) -I $(SRC_DIR)

--- a/src/lexer/buffer.c.h
+++ b/src/lexer/buffer.c.h
@@ -36,7 +36,7 @@ void lex_buffreset()
 
 const char *lex_get_buffstr()
 {
-    if (!lex_buffer || !lex_buffer->push_i) return "NULL";
+    if (!lex_buffer || !lex_buffer->push_i) return NULL;
     return lex_buffer->buffer;
 }
 

--- a/src/lexer/io.c.h
+++ b/src/lexer/io.c.h
@@ -21,25 +21,25 @@ char lex_getc(FILE *f)
         if (c == '\n') { lex_line_no++; lex_char_no = 0; }
         else if (lex_is_printable(c)) lex_char_no++;
     }
-    else if (c == '\n') { lex_line_no++; lex_char_no = 0; }
-    else if (lex_is_printable(c)) lex_char_no++;
+    if (lex_is_printable(c)) lex_char_no++;
     if (!lex_is_delimiter(c)) lex_buffpush(c);
+    if (c == '\n') { lex_line_no++; lex_char_no = 0; }
     return c;
 }
 
 char lex_ungetc(char *c, FILE *f)
 {
+    if (lex_is_printable(*c)) lex_char_no--;
     if (*c == '\n') { lex_line_no--; lex_char_no = -1; }
-    else if (lex_is_printable(*c)) lex_char_no--;
     if (*c != (char) EOF && !lex_is_delimiter(*c)) lex_buffpop();
     if (*c != (char) EOF) ungetc(*c, f);
     const char *tmp = lex_get_buffstr();
-    return *c = tmp[lex_buffer->push_i -1];
+    return *c = tmp ? tmp[lex_buffer->push_i -1] : 0;
 }
 
 bool lex_is_delimiter(char c)
 {
-    return c == '\t' || c == '\n' || c == '\r' || c == ' ';
+    return c == '\t' || c == '\r' || c == ' ';
 }
 
 bool lex_is_printable(char c)

--- a/src/lexer/io.c.h
+++ b/src/lexer/io.c.h
@@ -44,7 +44,8 @@ bool lex_is_delimiter(char c)
 
 bool lex_is_printable(char c)
 {
-    return (c >= 32 && c < 127) || lex_is_delimiter(c);
+    return ( c == 10 || (c >= 32 && c < 127) )
+        || lex_is_delimiter(c);
 }
 
 bool lex_isalmun_undr(char c)

--- a/src/lexer/match_keywords.c.h
+++ b/src/lexer/match_keywords.c.h
@@ -6,12 +6,12 @@
 LexToken lex_match_keywords(FILE *f, char ch)
 {
     if (!isalpha(ch)) return LEXTOK_INVALID;
-    // start at 1 as ch is already in buffer
+    /* start at 1 as ch is already in buffer */
     size_t kwdlen = 1;
     while (true) {
         ch = lex_getc(f);
         if (!isalpha(ch)) {
-            // unget last non alpha char
+            /* unget last non alpha char */
             lex_ungetc(&ch, f);
             break;
         }
@@ -37,7 +37,7 @@ LexToken lex_match_keywords(FILE *f, char ch)
     if (!strcmp(lex_get_buffstr(), "do"))        return LEXTOK_KWD_DO;
     if (!strcmp(lex_get_buffstr(), "var"))       return LEXTOK_KWD_VAR;
     if (!strcmp(lex_get_buffstr(), "pass"))      return LEXTOK_KWD_PASS;
-    // unget all characters except the first if all matches failed
+    /* unget all characters except the first if all matches failed */
     while (kwdlen > 1) {
         lex_ungetc(&ch, f);
         kwdlen--;

--- a/src/lexer/match_literals.c.h
+++ b/src/lexer/match_literals.c.h
@@ -6,12 +6,12 @@
 LexToken lex_match_bool(FILE *f, char ch)
 {
     if (!isalpha(ch)) return LEXTOK_INVALID;
-    // start at 1 as ch is already in buffer
+    /* start at 1 as ch is already in buffer */
     size_t currlen = 1;
     while (true) {
         ch = lex_getc(f);
         if (!isalpha(ch)) {
-            // unget last non alpha char
+            /* unget last non alpha char */
             lex_ungetc(&ch, f);
             break;
         }
@@ -19,7 +19,7 @@ LexToken lex_match_bool(FILE *f, char ch)
     }
     if (lex_get_buffstr()[0] == 't' && !strcmp(lex_get_buffstr(), "true"))  return LEXTOK_BOOL_LITERAL;
     if (lex_get_buffstr()[0] == 'f' && !strcmp(lex_get_buffstr(), "false")) return LEXTOK_BOOL_LITERAL;
-    // unget all characters except the first if all matches failed
+    /* unget all characters except the first if all matches failed */
     while (currlen > 1) {
         lex_ungetc(&ch, f);
         currlen--;
@@ -30,11 +30,11 @@ LexToken lex_match_bool(FILE *f, char ch)
 LexToken lex_match_char(FILE *f, char ch)
 {
     if (ch != '\'') return LEXTOK_INVALID;
-    // pop out quote symbol
+    /* pop out quote symbol */
     lex_buffpop();
     char prev2 = 0, prev = 0;
     while (true) {
-        // can't use lex_getc as it doesn't buffer delimiters
+        /* can't use lex_getc as it doesn't buffer delimiters */
         prev2 = prev;
         prev = ch;
         ch = getc(f);
@@ -61,13 +61,13 @@ LexToken lex_match_string(FILE *f, char ch)
             return LEXTOK_INVALID;
         }
     }
-    // after the above checks, ch is now either " or f
+    /* after the above checks, ch is now either " or f */
     LexToken tok = ch == '"' ? LEXTOK_STR_LITERAL : LEXTOK_INTERP_STR_LITERAL;
-    // pop out " or f symbol
+    /* pop out " or f symbol */
     lex_buffpop();
     char prev2 = 0, prev = 0;
     while (true) {
-        // can't use lex_getc as it doesn't buffer delimiters
+        /* can't use lex_getc as it doesn't buffer delimiters */
         prev2 = prev;
         prev = ch;
         ch = getc(f);
@@ -82,12 +82,12 @@ LexToken lex_match_string(FILE *f, char ch)
     return tok;
 }
 
-typedef enum {
+enum LexBase {
     LEXBASE_2  =  2,
     LEXBASE_8  =  8,
     LEXBASE_10 = 10,
     LEXBASE_16 = 16,
-} LexBase;
+};
 
 bool lex_isbindigit(char c) {
     return c >= '0' && c <= '1';
@@ -108,7 +108,7 @@ bool lex_ishexdigit(char c) {
 }
 
 typedef bool (*lex_digitchecker_ft)(char);
-lex_digitchecker_ft lex_get_dgitchecker(LexBase base)
+lex_digitchecker_ft lex_get_dgitchecker(enum LexBase base)
 {
     switch (base) {
         case LEXBASE_2: return lex_isbindigit;
@@ -118,22 +118,22 @@ lex_digitchecker_ft lex_get_dgitchecker(LexBase base)
     }
 }
 
-char lex_match_digits(FILE* f, char ch, LexBase base)
+char lex_match_digits(FILE* f, char ch, enum LexBase base)
 {
-    // get digit checker based on base
+    /* get digit checker based on base */
     lex_digitchecker_ft lex_isdigit = lex_get_dgitchecker(base);
-    // convert lower case hex digits to uppercase
+    /* convert lower case hex digits to uppercase */
     if (lex_isdigit(ch) && ch >= 'a' && ch <= 'f') {
         lex_buffpush(lex_buffpop() - ('a' - 'A'));
     }
-    // match [a-fA-F0-9_]+
+    /* match [a-fA-F0-9_]+ */
     while (lex_isdigit(ch)) {
         ch = lex_getc(f);
-        // convert lower case hex digits to uppercase
+        /* convert lower case hex digits to uppercase */
         if (lex_isdigit(ch) && ch >= 'a' && ch <= 'f') {
             lex_buffpush(lex_buffpop() - ('a' - 'A'));
         }
-        // if _ consume it but don't buffer it
+        /* if _ consume it but don't buffer it */
         if (ch == '_') {
             lex_buffpop();
             ch = lex_getc(f);
@@ -142,11 +142,13 @@ char lex_match_digits(FILE* f, char ch, LexBase base)
     return ch;
 }
 
-LexToken lex_match_unum(FILE *f, char ch, LexBase base)
+/* this function accepts numeric strings that start with any digit or '.'
+   and have the form (\d*)(\.\d+)?([ep][+-]?\d+)? */
+LexToken lex_match_unum(FILE *f, char ch, enum LexBase base)
 {
-    // get digit checker based on base
+    /* get digit checker based on base */
     lex_digitchecker_ft lex_isdigit = lex_get_dgitchecker(base);
-    // get token type based on base
+    /* get token type based on base */
     LexToken inttok, floattok;
     switch (base) {
         case LEXBASE_2:
@@ -167,102 +169,117 @@ LexToken lex_match_unum(FILE *f, char ch, LexBase base)
             break;
     }
     LexToken retok = LEXTOK_INVALID;
-    // match \d+
-    if (!lex_isdigit(ch)) return LEXTOK_INVALID;
-    ch = lex_match_digits(f, ch, base);
-    // integer matched
-    retok = inttok;
-    // match (\.\d+){0:1}
+    /* match \d* */
+    if (!lex_isdigit(ch) && ch != '.') return LEXTOK_INVALID;
+    if (ch != '.') {
+        ch = lex_match_digits(f, ch, base);
+        /* integer or integer part matched */
+        retok = inttok;
+    }
+    /* match (\.\d+){0:1} */
     if (ch == '.') {
         ch = lex_getc(f);
         if (!lex_isdigit(ch)) {
-            lex_ungetc(&ch, f);    // unget ch
-            lex_ungetc(&ch, f);    // unget '.'
+            lex_ungetc(&ch, f);    /* unget ch */
+            lex_ungetc(&ch, f);    /* unget '.' */
             return retok;
         }
         ch = lex_match_digits(f, ch, base);
-        // float matched
+        /* float matched */
         retok = floattok;
     }
-    // match ([ep][+-]\d+){0:1}
+    /* match ([ep][+-]?\d+){0:1} */
     if ((base != LEXBASE_16 && ch == 'e') || ch == 'p') {
-        // pop 'p' and push 'e', convert p to e
+        /* pop 'p' and push 'e', convert p to e */
+        char backup_expchar = ch;
         lex_buffpop();
         lex_buffpush('e');
-        // next char
+        /* next char */
         ch = lex_getc(f);
-        // consume + or - symbol
+        /* consume + or - symbol */
         if (ch == '+' || ch == '-') {
             ch = lex_getc(f);
             if (!lex_isdigit(ch)) {
-                lex_ungetc(&ch, f);    // unget ch
-                lex_ungetc(&ch, f);    // unget '+' or '-'
-                lex_ungetc(&ch, f);    // unget 'e' or 'p'
+                lex_ungetc(&ch, f);    /* unget ch */
+                lex_ungetc(&ch, f);    /* unget '+' or '-' */
+                /* unget 'e' or 'p' */
+                ch = lex_ungetc(&backup_expchar, f);
                 return retok;
             }
         }
         if (!lex_isdigit(ch)) {
-            lex_ungetc(&ch, f);    // unget ch
-            lex_ungetc(&ch, f);    // unget 'e' or 'p'
+            lex_ungetc(&ch, f);    /* unget ch */
+            /* unget 'e' or 'p' */
+            ch = lex_ungetc(&backup_expchar, f);
             return retok;
         }
         ch = lex_match_digits(f, ch, base);
     }
-    // if last matches failed unget last char
+    /* if last matches failed unget last char */
     lex_ungetc(&ch, f);
     return retok;
 }
 
+/* may accept only if the string starts w/ '+', '-', '.', digit or '0' */
 LexToken lex_match_numeric(FILE *f, char ch)
 {
-    // if starts with a 0
+    /* starts with '+' or '-' then consume the sign */
+    if (ch == '+' || ch == '-') {
+        ch = lex_getc(f);
+        if (!lex_isdigit(ch)) {
+            lex_ungetc(&ch, f);    /* unget ch */
+            lex_ungetc(&ch, f);    /* unget '+' or '-' */
+            return LEXTOK_INVALID;
+        }
+    }
+    /* if starts with a 0 */
     if (ch == '0') {
         ch = lex_getc(f);
         switch (ch) {
             case 'b': {
-                // pop "0b"
+                /* pop "0b" */
                 lex_buffpop();
                 lex_buffpop();
                 ch = lex_getc(f);
                 return lex_match_unum(f, ch, LEXBASE_2);
             }
             case 'x': {
-                // pop "0x"
+                /* pop "0x" */
                 lex_buffpop();
                 lex_buffpop();
                 ch = lex_getc(f);
                 return lex_match_unum(f, ch, LEXBASE_16);
             }
             default: {
-                // for values like 023... and 00.12... and many others
+                /* for values like 023... and 00.12... and many others */
                 if (isdigit(ch)) {
-                    lex_ungetc(&ch, f);  // unget curr char
-                    lex_buffpop();       // pop leading '0' from buffer
-                    ch = lex_getc(f);    // after '0'
+                    lex_ungetc(&ch, f);  /* unget curr char */
+                    lex_buffpop();       /* pop leading '0' from buffer */
+                    ch = lex_getc(f);    /* get back the unget char after '0' */
                     return lex_match_unum(f, ch, LEXBASE_8);
                 }
-                // for numbers like 0.12... or 0_34, or just 0
+                /* for numbers like 0.12... or 0_34, or just 0 */
                 else if (ch == '.' || ch == '_') {
-                    // unget leading 0
+                    /* unget leading 0 and start matching using unum */
                     lex_ungetc(&ch, f);
                     return lex_match_unum(f, ch, LEXBASE_10);
                 }
                 else {
-                    // unget ch and return int literal for '0'
+                    /* unget ch and return int literal for '0' */
                     lex_ungetc(&ch, f);
                     return LEXTOK_DECINT_LITERAL;
                 }
             }
         }
     }
-    // starts with any other number
+    /* starts with any other number */
     else if (isdigit(ch))
         return lex_match_unum(f, ch, LEXBASE_10);
-    // starts with '.'
+    /* starts with '.', eg .ddd, convert it to 0.ddd */
     else if (ch == '.') {
-        lex_ungetc(&ch, f);      // unget '.'
-        lex_buffpush(ch = '0');  // push a '0'
-        return lex_match_unum(f, ch, LEXBASE_10);
+        lex_ungetc(&ch, f);      /* unget '.' */
+        lex_buffpush('0');       /* push a '0' */
+        return lex_match_unum(f, '0', LEXBASE_10);
     }
     else return LEXTOK_INVALID;
 }

--- a/src/lexer/match_literals.c.h
+++ b/src/lexer/match_literals.c.h
@@ -226,7 +226,7 @@ LexToken lex_match_numeric(FILE *f, char ch)
     /* starts with '+' or '-' then consume the sign */
     if (ch == '+' || ch == '-') {
         ch = lex_getc(f);
-        if (!lex_isdigit(ch)) {
+        if (!isdigit(ch) && ch != '.') {
             lex_ungetc(&ch, f);    /* unget ch */
             lex_ungetc(&ch, f);    /* unget '+' or '-' */
             return LEXTOK_INVALID;

--- a/src/lexer/match_symbols.c.h
+++ b/src/lexer/match_symbols.c.h
@@ -219,6 +219,7 @@ LexToken lex_match_symbols(FILE *f, char ch)
             lex_buffree();
             return LEXTOK_EOF;
         }
+        case '\n': return LEXTOK_NEWLINE;
         default: return LEXTOK_INVALID;
     }
     return LEXTOK_INVALID;

--- a/src/lexer/tokens.c.h
+++ b/src/lexer/tokens.c.h
@@ -222,20 +222,20 @@ const char *lex_get_symbol(LexToken code)
         case LEXTOK_KWD_VAR:               return "var";
         case LEXTOK_KWD_PASS:              return "pass";
         // identifier
-        case LEXTOK_IDENTIFIER:            return lex_get_buffstr();
+        case LEXTOK_IDENTIFIER:            return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
         // literals
-        case LEXTOK_BOOL_LITERAL:          return lex_get_buffstr();
-        case LEXTOK_CHAR_LITERAL:          return lex_get_buffstr();
-        case LEXTOK_BINFLOAT_LITERAL:      return lex_get_buffstr();
-        case LEXTOK_OCTFLOAT_LITERAL:      return lex_get_buffstr();
-        case LEXTOK_DECFLOAT_LITERAL:      return lex_get_buffstr();
-        case LEXTOK_HEXFLOAT_LITERAL:      return lex_get_buffstr();
-        case LEXTOK_BININT_LITERAL:        return lex_get_buffstr();
-        case LEXTOK_OCTINT_LITERAL:        return lex_get_buffstr();
-        case LEXTOK_DECINT_LITERAL:        return lex_get_buffstr();
-        case LEXTOK_HEXINT_LITERAL:        return lex_get_buffstr();
-        case LEXTOK_STR_LITERAL:           return lex_get_buffstr();
-        case LEXTOK_INTERP_STR_LITERAL:    return lex_get_buffstr();
+        case LEXTOK_BOOL_LITERAL:          return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_CHAR_LITERAL:          return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_BINFLOAT_LITERAL:      return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_OCTFLOAT_LITERAL:      return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_DECFLOAT_LITERAL:      return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_HEXFLOAT_LITERAL:      return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_BININT_LITERAL:        return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_OCTINT_LITERAL:        return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_DECINT_LITERAL:        return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_HEXINT_LITERAL:        return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_STR_LITERAL:           return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
+        case LEXTOK_INTERP_STR_LITERAL:    return lex_get_buffstr() ? lex_get_buffstr() : "NULL";
         // default cases
         case LEXTOK_EOF:                   return "end-of-file";
         case LEXTOK_INVALID:               return "invalid token";

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,6 @@ int main(int argc, char **argv)
     if (!strcmp(argv[index], "-b") || !strcmp(argv[index], "--build")) {
         if (argc < 3) io_errndie("build file path not provided");
         lines = io_read_lines(argv[++index], &line_cnt);
-        if (!lines) io_errndie("build file content is null");
         ++index;
         if (index < argc) io_errndie("too many arguments: '%s' onwards", argv[index]);
     }

--- a/src/parser.y
+++ b/src/parser.y
@@ -537,7 +537,7 @@ void parse_interpret(FILE *f)
 #ifdef LEX_DEBUG
     LexToken tok = lex_get_nexttok(yyin);
     while (tok != LEXTOK_EOF) {
-        printf("%s: %s\n", lex_get_tokcode(tok), lex_get_buffstr());
+        printf("%s: %s\n", lex_get_tokcode(tok), lex_get_buffstr() ? lex_get_buffstr() : "NULL");
         tok = lex_get_nexttok(f);
     }
     printf("%s\n", lex_get_tokcode(tok));

--- a/src/parser.y
+++ b/src/parser.y
@@ -537,7 +537,7 @@ void parse_interpret(FILE *f)
 #ifdef LEX_DEBUG
     LexToken tok = lex_get_nexttok(yyin);
     while (tok != LEXTOK_EOF) {
-        printf("%s: %s\n", lex_get_tokcode(tok), lex_get_buffstr() ? lex_get_buffstr() : "NULL");
+        printf("%s: %s\n", lex_get_tokcode(tok), lex_get_symbol(tok));
         tok = lex_get_nexttok(f);
     }
     printf("%s\n", lex_get_tokcode(tok));


### PR DESCRIPTION
- lexer: updated code to match digits starting w/ + or -
- newlines are now read as a seperator instead of a delimiter
- tokens.c.h: checks if returned val from get_buffstr is NULL and prints NULL only if it indeed is NULL
- na: changed comment style
- no meed to null check lines retuned as it is done in the callee fn
- get_buffstr returns NULL instead of "NULL"
- newline is treated as a seperator instead of delimiter
- as get_buffstr returns NULL it must be checked before printing
- lex_match_literals: major changes to how int and floats are matched
- lexer: compilation issue fixed
- makefile: disabled lex o/p debug flag
