### PR TITLE
updates to language syntax

### DIFF
--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -1,4 +1,4 @@
-**Last updated on July 12, 2023**
+**Last updated on July 18, 2023**
 
 The following is a specification of the syntax and behaviour of the language.
 
@@ -178,6 +178,48 @@ An assignment is a part of an expression, which means you can do the same operat
 x = y = x = 5
 var u = (x = 4) if true else "hi"
 ```
+
+### Lists
+The language supports lists in the same syntax as that of Python.
+A single list can have multiple datatypes together.
+
+#### Example
+```
+proc test start
+    var x = [
+        [ 1, 2, 4, 5 ],
+        [ 1, 2, 4, 5 ],
+        [ 1, 2, 4, 5 ],
+        [ 1, 2, 4, 5 ],
+    ]
+end
+```
+
+#### Implementation
+They'll be stored as an array of union of multiple expressions and the type will be dynamically inferred when an element is accessed.
+
+## Semicolons
+Newlines or semicolons can be used to terminate a statement.
+
+If semicolon is used, one can write multiple statements in a single line.
+
+There's no up or downside in using either.
+If used at the end of a statement, the parser makes no distinction b/w newlines or semicolons.
+
+Even a combination of the two can be used wherever one desires.
+
+#### Example
+```
+proc test start
+    var x = 5; x = 0
+    ;
+end
+```
+
+## Indentation
+The parser ignores indentation and whitespaces completely.
+
+Only newlines are significant when used as statement termination symbols.
 
 ## Warning Prompt
 

--- a/docs/SyntaxTree.json
+++ b/docs/SyntaxTree.json
@@ -74,7 +74,7 @@
           },
           {
             "node": "statement",
-            "line_no": 7,
+            "line_no": 6,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",
@@ -616,7 +616,7 @@
           },
           {
             "node": "statement",
-            "line_no": 23,
+            "line_no": 22,
             "type": "STATEMENT_TYPE_ASSIGNMENT",
             "statement": {
               "node": "assignment",

--- a/docs/SyntaxTree.json
+++ b/docs/SyntaxTree.json
@@ -17,14 +17,10 @@
               "rhs": {
                 "node": "expression",
                 "op": "()",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "print"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "print"
                 },
                 "rhs_type": "EXPR_TYPE_LIST",
                 "rhs": {
@@ -33,15 +29,11 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_LITERAL",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_LITERAL",
-                        "operand": {
-                          "node": "literal",
-                          "type": "DATA_TYPE_STR",
-                          "data": "Hello world!"
-                        }
+                        "node": "literal",
+                        "type": "DATA_TYPE_STR",
+                        "data": "Hello world!"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -51,14 +43,10 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_IDENTIFIER",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_IDENTIFIER",
-                        "operand": {
-                          "node": "identifier",
-                          "identifier_name": "lf"
-                        }
+                        "node": "identifier",
+                        "identifier_name": "lf"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -85,14 +73,10 @@
               "rhs": {
                 "node": "expression",
                 "op": "()",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "input"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "input"
                 },
                 "rhs_type": "EXPR_TYPE_LIST",
                 "rhs": {
@@ -101,14 +85,10 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_IDENTIFIER",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_IDENTIFIER",
-                        "operand": {
-                          "node": "identifier",
-                          "identifier_name": "i64"
-                        }
+                        "node": "identifier",
+                        "identifier_name": "i64"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -131,24 +111,16 @@
               "condition": {
                 "node": "expression",
                 "op": "==",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "x"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "x"
                 },
-                "rhs_type": "EXPR_TYPE_OPERAND",
+                "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_LITERAL",
-                  "operand": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_I64",
-                    "data": 1
-                  }
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 1
                 },
                 "condition_type": "EXPR_TYPE_NULL",
                 "condition": null
@@ -166,14 +138,10 @@
                       "rhs": {
                         "node": "expression",
                         "op": "()",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_IDENTIFIER",
-                          "operand": {
-                            "node": "identifier",
-                            "identifier_name": "print"
-                          }
+                          "node": "identifier",
+                          "identifier_name": "print"
                         },
                         "rhs_type": "EXPR_TYPE_LIST",
                         "rhs": {
@@ -182,15 +150,11 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_LITERAL",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_LITERAL",
-                                "operand": {
-                                  "node": "literal",
-                                  "type": "DATA_TYPE_STR",
-                                  "data": "entered 1"
-                                }
+                                "node": "literal",
+                                "type": "DATA_TYPE_STR",
+                                "data": "entered 1"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,
@@ -200,14 +164,10 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_IDENTIFIER",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_IDENTIFIER",
-                                "operand": {
-                                  "node": "identifier",
-                                  "identifier_name": "lf"
-                                }
+                                "node": "identifier",
+                                "identifier_name": "lf"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,
@@ -231,24 +191,16 @@
                   "condition": {
                     "node": "expression",
                     "op": "==",
-                    "lhs_type": "EXPR_TYPE_OPERAND",
+                    "lhs_type": "EXPR_TYPE_IDENTIFIER",
                     "lhs": {
-                      "node": "operand",
-                      "type": "OPERAND_TYPE_IDENTIFIER",
-                      "operand": {
-                        "node": "identifier",
-                        "identifier_name": "x"
-                      }
+                      "node": "identifier",
+                      "identifier_name": "x"
                     },
-                    "rhs_type": "EXPR_TYPE_OPERAND",
+                    "rhs_type": "EXPR_TYPE_LITERAL",
                     "rhs": {
-                      "node": "operand",
-                      "type": "OPERAND_TYPE_LITERAL",
-                      "operand": {
-                        "node": "literal",
-                        "type": "DATA_TYPE_I64",
-                        "data": 2
-                      }
+                      "node": "literal",
+                      "type": "DATA_TYPE_I64",
+                      "data": 2
                     },
                     "condition_type": "EXPR_TYPE_NULL",
                     "condition": null
@@ -266,14 +218,10 @@
                           "rhs": {
                             "node": "expression",
                             "op": "()",
-                            "lhs_type": "EXPR_TYPE_OPERAND",
+                            "lhs_type": "EXPR_TYPE_IDENTIFIER",
                             "lhs": {
-                              "node": "operand",
-                              "type": "OPERAND_TYPE_IDENTIFIER",
-                              "operand": {
-                                "node": "identifier",
-                                "identifier_name": "print"
-                              }
+                              "node": "identifier",
+                              "identifier_name": "print"
                             },
                             "rhs_type": "EXPR_TYPE_LIST",
                             "rhs": {
@@ -282,15 +230,11 @@
                                 {
                                   "node": "expression",
                                   "op": "NOP",
-                                  "lhs_type": "EXPR_TYPE_OPERAND",
+                                  "lhs_type": "EXPR_TYPE_LITERAL",
                                   "lhs": {
-                                    "node": "operand",
-                                    "type": "OPERAND_TYPE_LITERAL",
-                                    "operand": {
-                                      "node": "literal",
-                                      "type": "DATA_TYPE_STR",
-                                      "data": "entered 2"
-                                    }
+                                    "node": "literal",
+                                    "type": "DATA_TYPE_STR",
+                                    "data": "entered 2"
                                   },
                                   "rhs_type": "EXPR_TYPE_NULL",
                                   "rhs": null,
@@ -300,14 +244,10 @@
                                 {
                                   "node": "expression",
                                   "op": "NOP",
-                                  "lhs_type": "EXPR_TYPE_OPERAND",
+                                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
                                   "lhs": {
-                                    "node": "operand",
-                                    "type": "OPERAND_TYPE_IDENTIFIER",
-                                    "operand": {
-                                      "node": "identifier",
-                                      "identifier_name": "lf"
-                                    }
+                                    "node": "identifier",
+                                    "identifier_name": "lf"
                                   },
                                   "rhs_type": "EXPR_TYPE_NULL",
                                   "rhs": null,
@@ -338,14 +278,10 @@
                       "rhs": {
                         "node": "expression",
                         "op": "()",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_IDENTIFIER",
-                          "operand": {
-                            "node": "identifier",
-                            "identifier_name": "print"
-                          }
+                          "node": "identifier",
+                          "identifier_name": "print"
                         },
                         "rhs_type": "EXPR_TYPE_LIST",
                         "rhs": {
@@ -354,15 +290,11 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_LITERAL",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_LITERAL",
-                                "operand": {
-                                  "node": "literal",
-                                  "type": "DATA_TYPE_STR",
-                                  "data": "entered {x}"
-                                }
+                                "node": "literal",
+                                "type": "DATA_TYPE_STR",
+                                "data": "entered {x}"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,
@@ -372,14 +304,10 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_IDENTIFIER",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_IDENTIFIER",
-                                "operand": {
-                                  "node": "identifier",
-                                  "identifier_name": "lf"
-                                }
+                                "node": "identifier",
+                                "identifier_name": "lf"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,
@@ -406,24 +334,16 @@
               "condition": {
                 "node": "expression",
                 "op": ">=",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "x"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "x"
                 },
-                "rhs_type": "EXPR_TYPE_OPERAND",
+                "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_LITERAL",
-                  "operand": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_I64",
-                    "data": 0
-                  }
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 0
                 },
                 "condition_type": "EXPR_TYPE_NULL",
                 "condition": null
@@ -441,14 +361,10 @@
                       "rhs": {
                         "node": "expression",
                         "op": "()",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_IDENTIFIER",
-                          "operand": {
-                            "node": "identifier",
-                            "identifier_name": "print"
-                          }
+                          "node": "identifier",
+                          "identifier_name": "print"
                         },
                         "rhs_type": "EXPR_TYPE_LIST",
                         "rhs": {
@@ -457,15 +373,11 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_LITERAL",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_LITERAL",
-                                "operand": {
-                                  "node": "literal",
-                                  "type": "DATA_TYPE_STR",
-                                  "data": "x = {x}"
-                                }
+                                "node": "literal",
+                                "type": "DATA_TYPE_STR",
+                                "data": "x = {x}"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,
@@ -489,37 +401,25 @@
                       "rhs": {
                         "node": "expression",
                         "op": "=",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_IDENTIFIER",
-                          "operand": {
-                            "node": "identifier",
-                            "identifier_name": "x"
-                          }
+                          "node": "identifier",
+                          "identifier_name": "x"
                         },
                         "rhs_type": "EXPR_TYPE_EXPRESSION",
                         "rhs": {
                           "node": "expression",
                           "op": "-",
-                          "lhs_type": "EXPR_TYPE_OPERAND",
+                          "lhs_type": "EXPR_TYPE_IDENTIFIER",
                           "lhs": {
-                            "node": "operand",
-                            "type": "OPERAND_TYPE_IDENTIFIER",
-                            "operand": {
-                              "node": "identifier",
-                              "identifier_name": "x"
-                            }
+                            "node": "identifier",
+                            "identifier_name": "x"
                           },
-                          "rhs_type": "EXPR_TYPE_OPERAND",
+                          "rhs_type": "EXPR_TYPE_LITERAL",
                           "rhs": {
-                            "node": "operand",
-                            "type": "OPERAND_TYPE_LITERAL",
-                            "operand": {
-                              "node": "literal",
-                              "type": "DATA_TYPE_I64",
-                              "data": 1
-                            }
+                            "node": "literal",
+                            "type": "DATA_TYPE_I64",
+                            "data": 1
                           },
                           "condition_type": "EXPR_TYPE_NULL",
                           "condition": null
@@ -543,27 +443,19 @@
               "rhs": {
                 "node": "expression",
                 "op": "=",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "x"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "x"
                 },
                 "rhs_type": "EXPR_TYPE_EXPRESSION",
                 "rhs": {
                   "node": "expression",
                   "op": "()",
-                  "lhs_type": "EXPR_TYPE_OPERAND",
+                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
                   "lhs": {
-                    "node": "operand",
-                    "type": "OPERAND_TYPE_IDENTIFIER",
-                    "operand": {
-                      "node": "identifier",
-                      "identifier_name": "input"
-                    }
+                    "node": "identifier",
+                    "identifier_name": "input"
                   },
                   "rhs_type": "EXPR_TYPE_LIST",
                   "rhs": {
@@ -572,15 +464,11 @@
                       {
                         "node": "expression",
                         "op": "NOP",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_LITERAL",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_LITERAL",
-                          "operand": {
-                            "node": "literal",
-                            "type": "DATA_TYPE_STR",
-                            "data": "prompt: "
-                          }
+                          "node": "literal",
+                          "type": "DATA_TYPE_STR",
+                          "data": "prompt: "
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -590,14 +478,10 @@
                       {
                         "node": "expression",
                         "op": "NOP",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_IDENTIFIER",
-                          "operand": {
-                            "node": "identifier",
-                            "identifier_name": "str"
-                          }
+                          "node": "identifier",
+                          "identifier_name": "str"
                         },
                         "rhs_type": "EXPR_TYPE_NULL",
                         "rhs": null,
@@ -624,14 +508,10 @@
               "rhs": {
                 "node": "expression",
                 "op": "()",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "print"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "print"
                 },
                 "rhs_type": "EXPR_TYPE_LIST",
                 "rhs": {
@@ -640,15 +520,11 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_LITERAL",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_LITERAL",
-                        "operand": {
-                          "node": "literal",
-                          "type": "DATA_TYPE_STR",
-                          "data": "entered {x}"
-                        }
+                        "node": "literal",
+                        "type": "DATA_TYPE_STR",
+                        "data": "entered {x}"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -658,14 +534,10 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_IDENTIFIER",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_IDENTIFIER",
-                        "operand": {
-                          "node": "identifier",
-                          "identifier_name": "lf"
-                        }
+                        "node": "identifier",
+                        "identifier_name": "lf"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -692,15 +564,11 @@
               "rhs": {
                 "node": "expression",
                 "op": "NOP",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_LITERAL",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_LITERAL",
-                  "operand": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_BUL",
-                    "data": true
-                  }
+                  "node": "literal",
+                  "type": "DATA_TYPE_BUL",
+                  "data": true
                 },
                 "rhs_type": "EXPR_TYPE_NULL",
                 "rhs": null,
@@ -719,14 +587,10 @@
               "rhs": {
                 "node": "expression",
                 "op": "()",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "print"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "print"
                 },
                 "rhs_type": "EXPR_TYPE_LIST",
                 "rhs": {
@@ -735,15 +599,11 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_LITERAL",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_LITERAL",
-                        "operand": {
-                          "node": "literal",
-                          "type": "DATA_TYPE_STR",
-                          "data": "bool value = {x}"
-                        }
+                        "node": "literal",
+                        "type": "DATA_TYPE_STR",
+                        "data": "bool value = {x}"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -753,14 +613,10 @@
                     {
                       "node": "expression",
                       "op": "NOP",
-                      "lhs_type": "EXPR_TYPE_OPERAND",
+                      "lhs_type": "EXPR_TYPE_IDENTIFIER",
                       "lhs": {
-                        "node": "operand",
-                        "type": "OPERAND_TYPE_IDENTIFIER",
-                        "operand": {
-                          "node": "identifier",
-                          "identifier_name": "lf"
-                        }
+                        "node": "identifier",
+                        "identifier_name": "lf"
                       },
                       "rhs_type": "EXPR_TYPE_NULL",
                       "rhs": null,
@@ -787,48 +643,32 @@
               "rhs": {
                 "node": "expression",
                 "op": "?:",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_LITERAL",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_LITERAL",
-                  "operand": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_I64",
-                    "data": 5
-                  }
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 5
                 },
-                "rhs_type": "EXPR_TYPE_OPERAND",
+                "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_LITERAL",
-                  "operand": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_I64",
-                    "data": 7
-                  }
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 7
                 },
                 "condition_type": "EXPR_TYPE_EXPRESSION",
                 "condition": {
                   "node": "expression",
                   "op": "==",
-                  "lhs_type": "EXPR_TYPE_OPERAND",
+                  "lhs_type": "EXPR_TYPE_IDENTIFIER",
                   "lhs": {
-                    "node": "operand",
-                    "type": "OPERAND_TYPE_IDENTIFIER",
-                    "operand": {
-                      "node": "identifier",
-                      "identifier_name": "x"
-                    }
+                    "node": "identifier",
+                    "identifier_name": "x"
                   },
-                  "rhs_type": "EXPR_TYPE_OPERAND",
+                  "rhs_type": "EXPR_TYPE_LITERAL",
                   "rhs": {
-                    "node": "operand",
-                    "type": "OPERAND_TYPE_LITERAL",
-                    "operand": {
-                      "node": "literal",
-                      "type": "DATA_TYPE_BUL",
-                      "data": false
-                    }
+                    "node": "literal",
+                    "type": "DATA_TYPE_BUL",
+                    "data": false
                   },
                   "condition_type": "EXPR_TYPE_NULL",
                   "condition": null
@@ -845,24 +685,16 @@
               "condition": {
                 "node": "expression",
                 "op": "==",
-                "lhs_type": "EXPR_TYPE_OPERAND",
+                "lhs_type": "EXPR_TYPE_IDENTIFIER",
                 "lhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_IDENTIFIER",
-                  "operand": {
-                    "node": "identifier",
-                    "identifier_name": "y"
-                  }
+                  "node": "identifier",
+                  "identifier_name": "y"
                 },
-                "rhs_type": "EXPR_TYPE_OPERAND",
+                "rhs_type": "EXPR_TYPE_LITERAL",
                 "rhs": {
-                  "node": "operand",
-                  "type": "OPERAND_TYPE_LITERAL",
-                  "operand": {
-                    "node": "literal",
-                    "type": "DATA_TYPE_I64",
-                    "data": 5
-                  }
+                  "node": "literal",
+                  "type": "DATA_TYPE_I64",
+                  "data": 5
                 },
                 "condition_type": "EXPR_TYPE_NULL",
                 "condition": null
@@ -880,14 +712,10 @@
                       "rhs": {
                         "node": "expression",
                         "op": "()",
-                        "lhs_type": "EXPR_TYPE_OPERAND",
+                        "lhs_type": "EXPR_TYPE_IDENTIFIER",
                         "lhs": {
-                          "node": "operand",
-                          "type": "OPERAND_TYPE_IDENTIFIER",
-                          "operand": {
-                            "node": "identifier",
-                            "identifier_name": "print"
-                          }
+                          "node": "identifier",
+                          "identifier_name": "print"
                         },
                         "rhs_type": "EXPR_TYPE_LIST",
                         "rhs": {
@@ -896,15 +724,11 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_LITERAL",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_LITERAL",
-                                "operand": {
-                                  "node": "literal",
-                                  "type": "DATA_TYPE_STR",
-                                  "data": "x was false"
-                                }
+                                "node": "literal",
+                                "type": "DATA_TYPE_STR",
+                                "data": "x was false"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,
@@ -914,14 +738,10 @@
                             {
                               "node": "expression",
                               "op": "NOP",
-                              "lhs_type": "EXPR_TYPE_OPERAND",
+                              "lhs_type": "EXPR_TYPE_IDENTIFIER",
                               "lhs": {
-                                "node": "operand",
-                                "type": "OPERAND_TYPE_IDENTIFIER",
-                                "operand": {
-                                  "node": "identifier",
-                                  "identifier_name": "lf"
-                                }
+                                "node": "identifier",
+                                "identifier_name": "lf"
                               },
                               "rhs_type": "EXPR_TYPE_NULL",
                               "rhs": null,

--- a/include/ast/nodes.h
+++ b/include/ast/nodes.h
@@ -107,14 +107,16 @@ struct AST_Block_t {
 
 enum AST_ExpressionType_t {
     EXPR_TYPE_EXPRESSION,
-    EXPR_TYPE_OPERAND,
+    EXPR_TYPE_LITERAL,
+    EXPR_TYPE_IDENTIFIER,
     EXPR_TYPE_LIST,
     EXPR_TYPE_NULL,
 };
 
 union AST_ExpressionUnion_t {
     AST_Expression_t *expr;
-    AST_Operand_t *oprnd;
+    AST_Literal_t *literal;
+    AST_Identifier_t *variable;
     AST_CommaSepList_t *lst;
 };
 

--- a/include/ast/nodes/create.h
+++ b/include/ast/nodes/create.h
@@ -32,7 +32,7 @@ AST_ForBlock_t      *AST_ForBlock_iterate(AST_Identifier_t *iter, AST_Operand_t 
 AST_Block_t         *AST_Block(AST_Statements_t *statements);
 
 AST_Expression_t    *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_Expression_t *rhs, AST_Expression_t *condition);
-AST_Expression_t    *AST_Expression_Operand(AST_Operand_t *operand);
+AST_Expression_t    *AST_Expression_Literal(AST_Literal_t *literal);
 AST_Expression_t    *AST_Expression_Identifier(AST_Identifier_t *identifier);
 AST_Expression_t    *AST_Expression_CommaSepList(AST_CommaSepList_t *comma_list);
 

--- a/src/ast/nodes/create.c.h
+++ b/src/ast/nodes/create.c.h
@@ -169,20 +169,21 @@ AST_Block_t *AST_Block(AST_Statements_t *statements)
     return block;
 }
 
-#define AST_EXPRESSION_ISOPERAND(expr_) ({          \
-    AST_Expression_t *expr = expr_;                 \
-    expr && expr->op == TOKOP_NOP                   \
-         && expr->lhs_type == EXPR_TYPE_OPERAND     \
-         && expr->rhs_type == EXPR_TYPE_NULL        \
-         && expr->condition_type == EXPR_TYPE_NULL; \
+#define AST_EXPRESSION_ISOPERAND(expr_) ({             \
+    AST_Expression_t *expr = expr_;                    \
+    expr && expr->op == TOKOP_NOP                      \
+         && ( expr->lhs_type == EXPR_TYPE_LITERAL      \
+           || expr->lhs_type == EXPR_TYPE_IDENTIFIER ) \
+         && expr->rhs_type == EXPR_TYPE_NULL           \
+         && expr->condition_type == EXPR_TYPE_NULL;    \
 })
 
-#define AST_EXPRESSION_ISCOMMALIST(expr_) ({        \
-    AST_Expression_t *expr = expr_;                 \
-    expr && expr->op == TOKOP_NOP                   \
-         && expr->lhs_type == EXPR_TYPE_LIST        \
-         && expr->rhs_type == EXPR_TYPE_NULL        \
-         && expr->condition_type == EXPR_TYPE_NULL; \
+#define AST_EXPRESSION_ISCOMMALIST(expr_) ({           \
+    AST_Expression_t *expr = expr_;                    \
+    expr && expr->op == TOKOP_NOP                      \
+         && expr->lhs_type == EXPR_TYPE_LIST           \
+         && expr->rhs_type == EXPR_TYPE_NULL           \
+         && expr->condition_type == EXPR_TYPE_NULL;    \
 })
 
 AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_Expression_t *rhs, AST_Expression_t *condition)
@@ -193,8 +194,7 @@ AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_E
     if ( AST_EXPRESSION_ISOPERAND(lhs) || AST_EXPRESSION_ISCOMMALIST(lhs) ) {
         expression->lhs_type = lhs->lhs_type;
         expression->lhs = lhs->lhs;
-        lhs->lhs.oprnd = NULL;
-        lhs->lhs.lst = NULL;
+        lhs->lhs.expr = NULL;
         lhs->lhs_type = EXPR_TYPE_NULL;
         AST_Expression_free(&lhs);
     } else {
@@ -205,8 +205,7 @@ AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_E
     if ( AST_EXPRESSION_ISOPERAND(rhs) || AST_EXPRESSION_ISCOMMALIST(rhs) ) {
         expression->rhs_type = rhs->lhs_type;
         expression->rhs = rhs->lhs;
-        rhs->lhs.oprnd = NULL;
-        rhs->lhs.lst = NULL;
+        rhs->lhs.expr = NULL;
         rhs->lhs_type = EXPR_TYPE_NULL;
         AST_Expression_free(&rhs);
     } else {
@@ -217,8 +216,7 @@ AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_E
     if ( AST_EXPRESSION_ISOPERAND(condition) || AST_EXPRESSION_ISCOMMALIST(condition) ) {
         expression->condition_type = condition->lhs_type;
         expression->condition = condition->lhs;
-        condition->lhs.oprnd = NULL;
-        condition->lhs.lst = NULL;
+        condition->lhs.expr = NULL;
         condition->lhs_type = EXPR_TYPE_NULL;
         AST_Expression_free(&condition);
     } else {
@@ -229,12 +227,12 @@ AST_Expression_t *AST_Expression(AST_Operator_t op, AST_Expression_t *lhs, AST_E
     return expression;
 }
 
-AST_Expression_t *AST_Expression_Operand(AST_Operand_t *operand)
+AST_Expression_t *AST_Expression_Literal(AST_Literal_t *literal)
 {
     AST_Expression_t *expression = (AST_Expression_t*) malloc(sizeof(AST_Expression_t));
     expression->op = TOKOP_NOP;
-    expression->lhs_type = EXPR_TYPE_OPERAND;
-    expression->lhs.oprnd = operand;
+    expression->lhs_type = EXPR_TYPE_LITERAL;
+    expression->lhs.literal = literal;
     expression->rhs_type = EXPR_TYPE_NULL;
     expression->rhs.expr = NULL;
     expression->condition_type = EXPR_TYPE_NULL;
@@ -246,8 +244,8 @@ AST_Expression_t *AST_Expression_Identifier(AST_Identifier_t *identifier)
 {
     AST_Expression_t *expression = (AST_Expression_t*) malloc(sizeof(AST_Expression_t));
     expression->op = TOKOP_NOP;
-    expression->lhs_type = EXPR_TYPE_OPERAND;
-    expression->lhs.oprnd = AST_Operand_Identifier(identifier);
+    expression->lhs_type = EXPR_TYPE_IDENTIFIER;
+    expression->lhs.variable = identifier;
     expression->rhs_type = EXPR_TYPE_NULL;
     expression->rhs.expr = NULL;
     expression->condition_type = EXPR_TYPE_NULL;

--- a/src/ast/nodes/destroy.c.h
+++ b/src/ast/nodes/destroy.c.h
@@ -161,8 +161,11 @@ void AST_Expression_free(AST_Expression_t **ptr)
         case EXPR_TYPE_EXPRESSION:
             AST_Expression_free(&expression->lhs.expr);
             break;
-        case EXPR_TYPE_OPERAND:
-            AST_Operand_free(&expression->lhs.oprnd);
+        case EXPR_TYPE_LITERAL:
+            AST_Literal_free(&expression->lhs.literal);
+            break;
+        case EXPR_TYPE_IDENTIFIER:
+            AST_Identifier_free(&expression->lhs.variable);
             break;
         case EXPR_TYPE_LIST:
             AST_CommaSepList_free(&expression->lhs.lst);
@@ -174,8 +177,11 @@ void AST_Expression_free(AST_Expression_t **ptr)
         case EXPR_TYPE_EXPRESSION:
             AST_Expression_free(&expression->rhs.expr);
             break;
-        case EXPR_TYPE_OPERAND:
-            AST_Operand_free(&expression->rhs.oprnd);
+        case EXPR_TYPE_LITERAL:
+            AST_Literal_free(&expression->rhs.literal);
+            break;
+        case EXPR_TYPE_IDENTIFIER:
+            AST_Identifier_free(&expression->rhs.variable);
             break;
         case EXPR_TYPE_LIST:
             AST_CommaSepList_free(&expression->rhs.lst);
@@ -187,8 +193,11 @@ void AST_Expression_free(AST_Expression_t **ptr)
         case EXPR_TYPE_EXPRESSION:
             AST_Expression_free(&expression->condition.expr);
             break;
-        case EXPR_TYPE_OPERAND:
-            AST_Operand_free(&expression->condition.oprnd);
+        case EXPR_TYPE_LITERAL:
+            AST_Literal_free(&expression->condition.literal);
+            break;
+        case EXPR_TYPE_IDENTIFIER:
+            AST_Identifier_free(&expression->condition.variable);
             break;
         case EXPR_TYPE_LIST:
             AST_CommaSepList_free(&expression->condition.lst);

--- a/src/ast/to_json.c.h
+++ b/src/ast/to_json.c.h
@@ -480,7 +480,7 @@ void AST2JSON_Literal(const AST_Literal_t *literal)
         case DATA_TYPE_F64:
             fprintf(AST2JSON_outfile, ", \"type\": \"DATA_TYPE_F64\"");
             fprintf(AST2JSON_outfile, ", \"data\": ");
-            fprintf(AST2JSON_outfile, "%f", literal->data.f64);
+            fprintf(AST2JSON_outfile, "%lf", literal->data.f64);
             break;
         case DATA_TYPE_STR:
         case DATA_TYPE_INTERP_STR: {

--- a/src/ast/to_json.c.h
+++ b/src/ast/to_json.c.h
@@ -323,10 +323,15 @@ void AST2JSON_Expression(const AST_Expression_t *expression)
             fprintf(AST2JSON_outfile, ", \"lhs\": ");
             AST2JSON_Expression(expression->lhs.expr);
             break;
-        case EXPR_TYPE_OPERAND:
-            fprintf(AST2JSON_outfile, ", \"lhs_type\": \"EXPR_TYPE_OPERAND\"");
+        case EXPR_TYPE_LITERAL:
+            fprintf(AST2JSON_outfile, ", \"lhs_type\": \"EXPR_TYPE_LITERAL\"");
             fprintf(AST2JSON_outfile, ", \"lhs\": ");
-            AST2JSON_Operand(expression->lhs.oprnd);
+            AST2JSON_Literal(expression->lhs.literal);
+            break;
+        case EXPR_TYPE_IDENTIFIER:
+            fprintf(AST2JSON_outfile, ", \"lhs_type\": \"EXPR_TYPE_IDENTIFIER\"");
+            fprintf(AST2JSON_outfile, ", \"lhs\": ");
+            AST2JSON_Identifier(expression->lhs.variable);
             break;
         case EXPR_TYPE_LIST:
             fprintf(AST2JSON_outfile, ", \"lhs_type\": \"EXPR_TYPE_LIST\"");
@@ -345,10 +350,15 @@ void AST2JSON_Expression(const AST_Expression_t *expression)
             fprintf(AST2JSON_outfile, ", \"rhs\": ");
             AST2JSON_Expression(expression->rhs.expr);
             break;
-        case EXPR_TYPE_OPERAND:
-            fprintf(AST2JSON_outfile, ", \"rhs_type\": \"EXPR_TYPE_OPERAND\"");
+        case EXPR_TYPE_LITERAL:
+            fprintf(AST2JSON_outfile, ", \"rhs_type\": \"EXPR_TYPE_LITERAL\"");
             fprintf(AST2JSON_outfile, ", \"rhs\": ");
-            AST2JSON_Operand(expression->rhs.oprnd);
+            AST2JSON_Literal(expression->rhs.literal);
+            break;
+        case EXPR_TYPE_IDENTIFIER:
+            fprintf(AST2JSON_outfile, ", \"rhs_type\": \"EXPR_TYPE_IDENTIFIER\"");
+            fprintf(AST2JSON_outfile, ", \"rhs\": ");
+            AST2JSON_Identifier(expression->rhs.variable);
             break;
         case EXPR_TYPE_LIST:
             fprintf(AST2JSON_outfile, ", \"rhs_type\": \"EXPR_TYPE_LIST\"");
@@ -367,10 +377,15 @@ void AST2JSON_Expression(const AST_Expression_t *expression)
             fprintf(AST2JSON_outfile, ", \"condition\": ");
             AST2JSON_Expression(expression->condition.expr);
             break;
-        case EXPR_TYPE_OPERAND:
-            fprintf(AST2JSON_outfile, ", \"condition_type\": \"EXPR_TYPE_OPERAND\"");
+        case EXPR_TYPE_LITERAL:
+            fprintf(AST2JSON_outfile, ", \"condition_type\": \"EXPR_TYPE_LITERAL\"");
             fprintf(AST2JSON_outfile, ", \"condition\": ");
-            AST2JSON_Operand(expression->condition.oprnd);
+            AST2JSON_Literal(expression->condition.literal);
+            break;
+        case EXPR_TYPE_IDENTIFIER:
+            fprintf(AST2JSON_outfile, ", \"condition_type\": \"EXPR_TYPE_IDENTIFIER\"");
+            fprintf(AST2JSON_outfile, ", \"condition\": ");
+            AST2JSON_Identifier(expression->condition.variable);
             break;
         case EXPR_TYPE_LIST:
             fprintf(AST2JSON_outfile, ", \"condition_type\": \"EXPR_TYPE_LIST\"");

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -138,6 +138,7 @@ void lex_throw(const char *msg)
 {
     if (!msg) abort();
     int line = lex_line_no;
+    /* if (lex_currtok == LEXTOK_NEWLINE) --line; */
     io_print_srcerr(line, lex_char_no, "lexing error: after token '%s': %s", lex_get_symbol(lex_currtok), msg);
     exit(ERR_LEXER);
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -123,7 +123,7 @@ LexToken lex_get_nexttok(FILE *f)
     else if (ch == '\'') return lex_match_char(f, ch);
     else if (ch == '"') return lex_match_string(f, ch);
     else if (isdigit(ch)) return lex_match_numeric(f, ch);
-    else if (ch == '.' || ch == '+' || ch == '-') {
+    else if (ch == '.') {
         LexToken currtok = lex_match_numeric(f, ch);
         if (currtok == LEXTOK_INVALID)
             return lex_match_symbols(f, ch);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -138,7 +138,6 @@ void lex_throw(const char *msg)
 {
     if (!msg) abort();
     int line = lex_line_no;
-    if (lex_currtok == LEXTOK_NEWLINE) --line;
     io_print_srcerr(line, lex_char_no, "lexing error: after token '%s': %s", lex_get_symbol(lex_currtok), msg);
     exit(ERR_LEXER);
 }

--- a/src/lexer/io.c.h
+++ b/src/lexer/io.c.h
@@ -18,12 +18,10 @@ char lex_getc(FILE *f)
         if (c == (char) EOF) return (char) EOF;
         if (!lex_is_printable(c))
             lex_throw("un-printable character found");
-        if (c == '\n') { lex_line_no++; lex_char_no = 0; }
-        else if (lex_is_printable(c)) lex_char_no++;
     }
-    if (lex_is_printable(c)) lex_char_no++;
-    if (!lex_is_delimiter(c)) lex_buffpush(c);
     if (c == '\n') { lex_line_no++; lex_char_no = 0; }
+    else if (lex_is_printable(c)) lex_char_no++;
+    if (!lex_is_delimiter(c)) lex_buffpush(c);
     return c;
 }
 

--- a/src/lexer/match_literals.c.h
+++ b/src/lexer/match_literals.c.h
@@ -223,14 +223,6 @@ LexToken lex_match_unum(FILE *f, char ch, enum LexBase base)
 /* may accept only if the string starts w/ '+', '-', '.', digit or '0' */
 LexToken lex_match_numeric(FILE *f, char ch)
 {
-    /* starts with '+' or '-' then consume the sign */
-    if (ch == '+' || ch == '-') {
-        ch = lex_getc(f);
-        if (!isdigit(ch) && ch != '.') {
-            lex_ungetc(&ch, f);    /* unget ch */
-            return LEXTOK_INVALID;
-        }
-    }
     /* if starts with a 0 */
     if (ch == '0') {
         ch = lex_getc(f);
@@ -271,15 +263,9 @@ LexToken lex_match_numeric(FILE *f, char ch)
             }
         }
     }
-    /* starts with any other number */
-    else if (isdigit(ch))
+    /* starts with any other number or '.' */
+    else if (isdigit(ch) || ch == '.')
         return lex_match_unum(f, ch, LEXBASE_10);
-    /* starts with '.', eg .ddd, convert it to 0.ddd */
-    else if (ch == '.') {
-        lex_ungetc(&ch, f);      /* unget '.' */
-        lex_buffpush('0');       /* push a '0' */
-        return lex_match_unum(f, '0', LEXBASE_10);
-    }
     else return LEXTOK_INVALID;
 }
 

--- a/src/lexer/match_literals.c.h
+++ b/src/lexer/match_literals.c.h
@@ -190,10 +190,10 @@ LexToken lex_match_unum(FILE *f, char ch, enum LexBase base)
     }
     /* match ([ep][+-]?\d+){0:1} */
     if ((base != LEXBASE_16 && ch == 'e') || ch == 'p') {
-        /* pop 'p' and push 'e', convert p to e */
+        /* pop 'e' and push 'p', convert e to p */
         char backup_expchar = ch;
         lex_buffpop();
-        lex_buffpush('e');
+        lex_buffpush('p');
         /* next char */
         ch = lex_getc(f);
         /* consume + or - symbol */

--- a/src/parser.y
+++ b/src/parser.y
@@ -437,6 +437,7 @@ multiplicative_expression:
 
 unary_expression:
     postfix_expression                                  { $$ = $1; }
+    | "+" unary_expression                              { $$ = AST_Expression($1, NULL, $2, NULL); }
     | "-" unary_expression                              { $$ = AST_Expression($1, NULL, $2, NULL); }
     | "!" unary_expression                              { $$ = AST_Expression($1, NULL, $2, NULL); }
     | "~" unary_expression                              { $$ = AST_Expression($1, NULL, $2, NULL); }

--- a/src/parser.y
+++ b/src/parser.y
@@ -265,8 +265,15 @@ FILE *yyin = NULL;
 %%
 
 nwl:
-    nwl "\n" { $$ = $1 + 1; }
-    | "\n"   { $$ = 1; }
+    %empty     { $$ = 0; }
+    | nwl "\n" { $$ = $1 + 1; }
+    ;
+
+trm:
+    trm ";"    { $$ = $1; }
+    | ";"      { $$ = 0; }
+    | trm "\n" { $$ = $1 + 1; }
+    | "\n"     { $$ = 1; }
     ;
 
 /* Push module name to a stack */
@@ -448,10 +455,10 @@ unary_expression:
 postfix_expression:
     primary_expression                                  { $$ = $1; }
     | postfix_expression "(" ")"                        { $$ = AST_Expression(TOKOP_FNCALL, $1, NULL, NULL); }
-    | postfix_expression "(" comma_list ")"             { $$ = AST_Expression(TOKOP_FNCALL, $1,
+    | postfix_expression "(" nwl comma_list ")"         { $$ = AST_Expression(TOKOP_FNCALL, $1,
                                                             AST_Expression_CommaSepList($3), NULL);
                                                         }
-    | postfix_expression "[" expression "]"             { $$ = AST_Expression(TOKOP_INDEXING, $1, $3, NULL); }
+    | postfix_expression "[" nwl expression "]"         { $$ = AST_Expression(TOKOP_INDEXING, $1, $3, NULL); }
     | postfix_expression "++"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "--"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "." identifier                 { $$ = AST_Expression($2, $1,
@@ -469,7 +476,8 @@ primary_expression:
 
 comma_list:
     expression                                          { $$ = AST_CommaSepList(NULL, $1); }
-    | expression "," comma_list                         { $$ = AST_CommaSepList($3, $1); }
+    | expression "," nwl                                { $$ = AST_CommaSepList(NULL, $1); }
+    | expression "," nwl comma_list                     { $$ = AST_CommaSepList($4, $1); }
     ;
 
 operand:
@@ -491,7 +499,7 @@ literal:
     | LEXTOK_STR_LITERAL                                { $$ = AST_Literal_str($1); }
     | LEXTOK_INTERP_STR_LITERAL                         { $$ = AST_Literal_interp_str($1); }
     | "[" "]"                                           { $$ = AST_Literal_lst(NULL); }
-    | "[" comma_list "]"                                { $$ = AST_Literal_lst($2); }
+    | "[" nwl comma_list "]"                            { $$ = AST_Literal_lst($2); }
     ;
 
 identifier:

--- a/src/parser.y
+++ b/src/parser.y
@@ -221,6 +221,7 @@ FILE *yyin = NULL;
 
 
 %type <line_count> nwl
+%type <line_count> trm
 
 /* semantic types of each parser rule */
 %type <astnode_statements>         statements
@@ -279,7 +280,7 @@ trm:
 /* Push module name to a stack */
 module:
     { AST_ModuleStack_push(AST_Identifier(strdup("main"))); } program { AST_ModuleStack_pop(); }
-    | "module" identifier nwl { AST_ModuleStack_push($2); } program { AST_ModuleStack_pop(); }
+    | "module" identifier trm { AST_ModuleStack_push($2); } program { AST_ModuleStack_pop(); }
     ;
 
 /* A program is empty or a single procedure or multiple procedures */
@@ -290,7 +291,7 @@ program:
 
 /* Map each module name to a map of procedures */
 procedure:
-    "proc" identifier "start" nwl statements "end" nwl  { AST_ProcedureMap_add((AST_Identifier_t*) AST_ModuleStack_top(), $2, $5); }
+    "proc" identifier "start" trm statements "end" trm  { AST_ProcedureMap_add((AST_Identifier_t*) AST_ModuleStack_top(), $2, $5); }
     ;
 
 statements:
@@ -299,10 +300,10 @@ statements:
     ;
 
 statement:
-    "pass" nwl                                          { $$ = AST_Statement_empty(lex_line_no - $2); }
-    | "return" expression nwl                           { $$ = AST_Statement_return($2, lex_line_no - $3); }
-    | assignment nwl                                    { $$ = AST_Statement_Assignment($1, lex_line_no - $2); }
-    | compound_statement nwl                            { $$ = AST_Statement_CompoundSt($1, lex_line_no - $2); }
+    "pass" trm                                          { $$ = AST_Statement_empty(lex_line_no - $2); }
+    | "return" expression trm                           { $$ = AST_Statement_return($2, lex_line_no - $3); }
+    | assignment trm                                    { $$ = AST_Statement_Assignment($1, lex_line_no - $2); }
+    | compound_statement trm                            { $$ = AST_Statement_CompoundSt($1, lex_line_no - $2); }
     ;
 
 assignment:
@@ -318,10 +319,10 @@ compound_statement:
     ;
 
 if_block:
-    "if" condition "then" nwl statements "end"                                            { $$ = AST_IfBlock($2, $5, NULL, NULL); }
-    | "if" condition "then" nwl statements "else" nwl statements "end"                    { $$ = AST_IfBlock($2, $5, NULL, $8); }
-    | "if" condition "then" nwl statements else_if_block "end"                            { $$ = AST_IfBlock($2, $5, $6, NULL); }
-    | "if" condition "then" nwl statements else_if_block "else" nwl statements "end"      { $$ = AST_IfBlock($2, $5, $6, $9); }
+    "if" condition "then" trm statements "end"                                            { $$ = AST_IfBlock($2, $5, NULL, NULL); }
+    | "if" condition "then" trm statements "else" trm statements "end"                    { $$ = AST_IfBlock($2, $5, NULL, $8); }
+    | "if" condition "then" trm statements else_if_block "end"                            { $$ = AST_IfBlock($2, $5, $6, NULL); }
+    | "if" condition "then" trm statements else_if_block "else" trm statements "end"      { $$ = AST_IfBlock($2, $5, $6, $9); }
     ;
 
 else_if_block:
@@ -330,22 +331,22 @@ else_if_block:
     ;
 
 else_if_statement:
-    "else" "if" condition "then" nwl statements         { $$ = AST_ElseIfSt($3, $6); }
-    | "elif" condition "then" nwl statements            { $$ = AST_ElseIfSt($2, $5); }
+    "else" "if" condition "then" trm statements         { $$ = AST_ElseIfSt($3, $6); }
+    | "elif" condition "then" trm statements            { $$ = AST_ElseIfSt($2, $5); }
     ;
 
 while_block:
-    "while" condition "do" nwl statements "end"         { $$ = AST_WhileBlock($2, $5); }
+    "while" condition "do" trm statements "end"         { $$ = AST_WhileBlock($2, $5); }
     ;
 
 for_block:
-    "for" identifier "from" operand "to" operand "do" nwl statements "end"                { $$ = AST_ForBlock($2, $4, $6, NULL, $9); }
-    | "for" identifier "from" operand "to" operand "by" operand "do" nwl statements "end" { $$ = AST_ForBlock($2, $4, $6, $8, $11); }
-    | "for" identifier "in" operand "do" nwl statements "end"                             { $$ = AST_ForBlock_iterate($2, $4, $7); }
+    "for" identifier "from" operand "to" operand "do" trm statements "end"                { $$ = AST_ForBlock($2, $4, $6, NULL, $9); }
+    | "for" identifier "from" operand "to" operand "by" operand "do" trm statements "end" { $$ = AST_ForBlock($2, $4, $6, $8, $11); }
+    | "for" identifier "in" operand "do" trm statements "end"                             { $$ = AST_ForBlock_iterate($2, $4, $7); }
     ;
 
 block:
-    "block" nwl statements "end"                        { $$ = AST_Block($3); }
+    "block" trm statements "end"                        { $$ = AST_Block($3); }
     ;
 
 condition:

--- a/src/parser.y
+++ b/src/parser.y
@@ -457,9 +457,9 @@ postfix_expression:
     primary_expression                                  { $$ = $1; }
     | postfix_expression "(" ")"                        { $$ = AST_Expression(TOKOP_FNCALL, $1, NULL, NULL); }
     | postfix_expression "(" nwl comma_list ")"         { $$ = AST_Expression(TOKOP_FNCALL, $1,
-                                                            AST_Expression_CommaSepList($3), NULL);
+                                                            AST_Expression_CommaSepList($4), NULL);
                                                         }
-    | postfix_expression "[" nwl expression "]"         { $$ = AST_Expression(TOKOP_INDEXING, $1, $3, NULL); }
+    | postfix_expression "[" nwl expression "]"         { $$ = AST_Expression(TOKOP_INDEXING, $1, $4, NULL); }
     | postfix_expression "++"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "--"                           { $$ = AST_Expression($2, $1, NULL, NULL); }
     | postfix_expression "." identifier                 { $$ = AST_Expression($2, $1,
@@ -471,7 +471,8 @@ postfix_expression:
     ;
 
 primary_expression:
-    operand                                             { $$ = AST_Expression_Operand($1); }
+    literal                                             { $$ = AST_Expression_Literal($1); }
+    | identifier                                        { $$ = AST_Expression_Identifier($1); }
     | "(" expression ")"                                { $$ = $2; }
     ;
 
@@ -500,7 +501,7 @@ literal:
     | LEXTOK_STR_LITERAL                                { $$ = AST_Literal_str($1); }
     | LEXTOK_INTERP_STR_LITERAL                         { $$ = AST_Literal_interp_str($1); }
     | "[" "]"                                           { $$ = AST_Literal_lst(NULL); }
-    | "[" nwl comma_list "]"                            { $$ = AST_Literal_lst($2); }
+    | "[" nwl comma_list "]"                            { $$ = AST_Literal_lst($3); }
     ;
 
 identifier:

--- a/src/parser.y
+++ b/src/parser.y
@@ -541,6 +541,7 @@ void parse_throw(const char *msg)
 {
     if (!msg) abort();
     int line = lex_line_no;
+    if (lex_currtok == LEXTOK_NEWLINE) --line;
     io_print_srcerr(line, lex_char_no, "parsing error: %s on '%s'", msg, lex_get_symbol(lex_currtok));
     exit(ERR_PARSER);
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -532,7 +532,6 @@ void parse_throw(const char *msg)
 {
     if (!msg) abort();
     int line = lex_line_no;
-    if (lex_currtok == LEXTOK_NEWLINE) --line;
     io_print_srcerr(line, lex_char_no, "parsing error: %s on '%s'", msg, lex_get_symbol(lex_currtok));
     exit(ERR_PARSER);
 }

--- a/src/parser/parse_f64.c.h
+++ b/src/parser/parse_f64.c.h
@@ -35,7 +35,7 @@ double parse_float(const char *str, int base)
     const char *exp_index = endptr;
     result += (double) fraction / pow(base, exp_index - dot_index -1);
     if (*endptr == '\0') return sign * result;
-    if (*endptr != 'e') parse_throw("invalid float format 2; wtf was the lexer designer doing?");
+    if (*endptr != 'p') parse_throw("invalid float format 2; wtf was the lexer designer doing?");
 
     /* parse the exponent if available */
     const int64_t exponent = strtol(exp_index +1, &endptr, base);

--- a/src/parser/parse_f64.c.h
+++ b/src/parser/parse_f64.c.h
@@ -10,94 +10,39 @@
 
 #include "parser.h"
 
-double parse_float(const char *str, int base) {
-    const int MAX_EXP_LEN = 4;
-    const int BUF_SIZE = 128;
-    int len = strlen(str);
-    char *buf = (char*) malloc(BUF_SIZE);
-    int buf_len = 0;
-    bool point_seen = false;
-    bool exp_seen = false;
-    int exp_sign = 1;
-    int exp_val = 0;
+double parse_float(const char *str, int base)
+{
+    int sign = 1;
+    double result = 0.0;
+    char *endptr = NULL;
 
-    for (int i = 0; i < len; i++) {
-        char c = str[i];
-        if (c == '.') {
-            if (point_seen || exp_seen) {
-                parse_throw("invalid floating point format");
-            }
-            point_seen = true;
-            continue;
-        }
-        if (c == 'p' || c == 'P') {
-            if (!point_seen || exp_seen) {
-                parse_throw("invalid exponent format");
-            }
-            exp_seen = true;
-            i++;
-            if (i >= len) {
-                parse_throw("invalid exponent format");
-            }
-            char exp_buf[MAX_EXP_LEN];
-            int exp_buf_len = 0;
-            if (str[i] == '+' || str[i] == '-') {
-                if (str[i] == '-') {
-                    exp_sign = -1;
-                }
-                i++;
-                if (i >= len) {
-                    parse_throw("invalid exponent format");
-                }
-            }
-            while (i < len && exp_buf_len < MAX_EXP_LEN) {
-                char exp_c = str[i];
-                if (!isdigit(exp_c)) {
-                    parse_throw("invalid exponent format");
-                }
-                exp_buf[exp_buf_len] = exp_c;
-                exp_buf_len++;
-                i++;
-            }
-            if (exp_buf_len == 0) {
-                parse_throw("invalid exponent format");
-            }
-            exp_val = strtol(exp_buf, NULL, 10);
-            exp_val *= exp_sign;
-            if (i < len) {
-                parse_throw("invalid exponent format");
-            }
-            break;
-        }
-
-        if (!isalnum(c)) {
-            parse_throw("invalid character in input");
-        }
-
-        if (isdigit(c) && c >= '0' + base) {
-            parse_throw("invalid character in input for given base");
-        }
-
-        if (isalpha(c) && toupper(c) >= 'A' + base - 10) {
-            parse_throw("invalid character in input for given base");
-        }
-
-        if (buf_len >= BUF_SIZE - 1) {
-            parse_throw("token too long");
-        }
-        buf[buf_len] = c;
-        buf_len++;
+    /* check for sign */
+    if (str[0] == '-') {
+        sign = -1;
+        ++str;
+    } else if (str[0] == '+') {
+        ++str;
     }
-    if (buf_len == 0 || (!point_seen && !exp_seen)) {
-        parse_throw("invalid floating point format");
-    }
-    buf[buf_len] = '\0';
-    double val = strtod(buf, NULL);
-    if (exp_seen) {
-        val *= pow(base, exp_val);
-    }
-    free(buf);
-    return (int64_t)val;
+
+    /* parse the integer */
+    result = strtol(str, &endptr, base);
+    const char *dot_index = endptr;
+    if (*endptr == '\0') return sign * result;
+    if (*endptr != '.') parse_throw("invalid float format 1; wtf was the lexer designer doing?");
+
+    /* parse the fraction if available */ 
+    const int64_t fraction = strtol(dot_index +1, &endptr, base);
+    const char *exp_index = endptr;
+    result += (double) fraction / pow(base, exp_index - dot_index -1);
+    if (*endptr == '\0') return sign * result;
+    if (*endptr != 'e') parse_throw("invalid float format 2; wtf was the lexer designer doing?");
+
+    /* parse the exponent if available */
+    const int64_t exponent = strtol(exp_index +1, &endptr, base);
+    result *= pow(base, exponent);
+    if (*endptr != '\0') parse_throw("invalid float format 3; wtf was the lexer designer doing?");
+
+    return sign * result;
 }
 
 #else

--- a/src/parser/parse_i64.c.h
+++ b/src/parser/parse_i64.c.h
@@ -24,11 +24,8 @@ int64_t parse_int(const char *str, int base)
     errno = 0;
 
     /* handle scientific notation separately */
-    if ( (exp_loc = strchr(str, 'e')) ) {
-        /* convert to 'p' from 'e' as for hex values,
-           'e' will cause issues as we are using strtol */
-        *exp_loc = 'p';
-        /* parse the integer part before the 'e' */
+    if ( (exp_loc = strchr(str, 'p')) ) {
+        /* parse the integer part before the 'p' */
         result = strtol(str, &endptr, base);
         if (errno || *endptr != 'p')
             parse_throw("invalid integer format 1; wtf was the lexer designer doing?");
@@ -41,17 +38,13 @@ int64_t parse_int(const char *str, int base)
             parse_throw("invalid integer format 2; wtf was the lexer designer doing?");
         /* check that the resulting value is representable in int64_t */
         if (exponent >= 0) {
-            if ( exponent > 18 || result >= INT64_MAX / (int64_t) (1LL * pow(base, exponent)) ) {
-                *exp_loc = 'e';
+            if ( exponent > 18 || result >= INT64_MAX / (int64_t) (1LL * pow(base, exponent)) )
                 parse_throw("integer overflow");
-            }
             /* multiply by base ^ exponent */
             result *= (int64_t) (1LL * pow(base, exponent));
         } else {
-            if ( exponent < -18 || result <= INT64_MIN / (int64_t) (1LL * pow(base, -exponent)) ) {
-                *exp_loc = 'e';
+            if ( exponent < -18 || result <= INT64_MIN / (int64_t) (1LL * pow(base, -exponent)) )
                 parse_throw("integer underflow");
-            }
             /* divide by base ^ exponent */
             result *= (int64_t) (1LL * pow(base, exponent));
         }

--- a/src/parser/parse_i64.c.h
+++ b/src/parser/parse_i64.c.h
@@ -53,7 +53,7 @@ int64_t parse_int(const char *str, int base)
                 parse_throw("integer underflow");
             }
             /* divide by base ^ exponent */
-            result /= (int64_t) (1LL * pow(base, exponent));
+            result *= (int64_t) (1LL * pow(base, exponent));
         }
     } else {
         /* parse the integer value using strtol */

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -15,7 +15,7 @@ proc main start
 
     while x >= 0 do
         print(f"x = {x}")
-        x = x -1
+        x = x - 1
     end
 
     x = input("prompt: ", str)


### PR DESCRIPTION
- lexer bug fix: exponent of int bug
- parse_float fixes: this fn kinda works for most float values
- lexer + parser: replace e for exponent w/ p to reduce confusion in hex
- na
- fixed lexing issue where a-1 was lexed as identifier<a> and literal<-1>
- line number issues fixed
- newly gen syntax tree
- changes to nwl production
- added support for semicolons
- parser: errors happening after \n token were reported at next line; fixed
- an expression node can directly be a literal or identifier
- continuation of last commit
- updated syntax docs
